### PR TITLE
custom schema generation to support intellij-hcl plugin

### DIFF
--- a/cf.json
+++ b/cf.json
@@ -1,0 +1,1454 @@
+{
+  "name": "cf",
+  "type": "provider",
+  "version": "0.9.5",
+  "provider": {
+    "api_url": {
+      "Type": "TypeString",
+      "Required": true,
+      "Default": {
+        "Type": "string"
+      },
+      "Elem": {}
+    },
+    "ca_cert": {
+      "Type": "TypeString",
+      "Required": true,
+      "Default": {
+        "Type": "string"
+      },
+      "Elem": {}
+    },
+    "password": {
+      "Type": "TypeString",
+      "Required": true,
+      "Default": {
+        "Type": "string"
+      },
+      "Elem": {}
+    },
+    "skip_ssl_validation": {
+      "Type": "TypeBool",
+      "Required": true,
+      "Default": {
+        "Type": "string",
+        "Value": "true"
+      },
+      "Elem": {}
+    },
+    "uaa_client_id": {
+      "Type": "TypeString",
+      "Optional": true,
+      "Default": {
+        "Type": "string"
+      },
+      "Elem": {}
+    },
+    "uaa_client_secret": {
+      "Type": "TypeString",
+      "Optional": true,
+      "Default": {
+        "Type": "string"
+      },
+      "Elem": {}
+    },
+    "user": {
+      "Type": "TypeString",
+      "Required": true,
+      "Default": {
+        "Type": "string"
+      },
+      "Elem": {}
+    }
+  },
+  "resources": {
+    "cf_app": {
+      "add_content": {
+        "Type": "TypeList",
+        "Optional": true,
+        "Default": {},
+        "Elem": {
+          "Type": "SchemaInfo",
+          "Info": {
+            "destination": {
+              "Type": "TypeString",
+              "Required": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "source": {
+              "Type": "TypeString",
+              "Required": true,
+              "Default": {},
+              "Elem": {}
+            }
+          }
+        }
+      },
+      "buildpack": {
+        "Type": "TypeString",
+        "Optional": true,
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "command": {
+        "Type": "TypeString",
+        "Optional": true,
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "disk_quota": {
+        "Type": "TypeInt",
+        "Optional": true,
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "enable_ssh": {
+        "Type": "TypeBool",
+        "Optional": true,
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "environment": {
+        "Type": "TypeMap",
+        "Optional": true,
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "git": {
+        "Type": "TypeList",
+        "Optional": true,
+        "MaxItems": 1,
+        "ConflictsWith": [
+          "url",
+          "github_release"
+        ],
+        "Default": {},
+        "Elem": {
+          "Type": "SchemaInfo",
+          "Info": {
+            "branch": {
+              "Type": "TypeString",
+              "Optional": true,
+              "ConflictsWith": [
+                "git.tag"
+              ],
+              "Default": {},
+              "Elem": {}
+            },
+            "key": {
+              "Type": "TypeString",
+              "Optional": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "password": {
+              "Type": "TypeString",
+              "Optional": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "tag": {
+              "Type": "TypeString",
+              "Optional": true,
+              "ConflictsWith": [
+                "git.branch"
+              ],
+              "Default": {},
+              "Elem": {}
+            },
+            "url": {
+              "Type": "TypeString",
+              "Required": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "user": {
+              "Type": "TypeString",
+              "Optional": true,
+              "Default": {},
+              "Elem": {}
+            }
+          }
+        }
+      },
+      "github_release": {
+        "Type": "TypeList",
+        "Optional": true,
+        "MaxItems": 1,
+        "ConflictsWith": [
+          "url",
+          "git"
+        ],
+        "Default": {},
+        "Elem": {
+          "Type": "SchemaInfo",
+          "Info": {
+            "filename": {
+              "Type": "TypeString",
+              "Required": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "owner": {
+              "Type": "TypeString",
+              "Required": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "repo": {
+              "Type": "TypeString",
+              "Required": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "token": {
+              "Type": "TypeString",
+              "Optional": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "version": {
+              "Type": "TypeString",
+              "Required": true,
+              "Default": {},
+              "Elem": {}
+            }
+          }
+        }
+      },
+      "health_check_http_endpoint": {
+        "Type": "TypeString",
+        "Optional": true,
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "health_check_timeout": {
+        "Type": "TypeInt",
+        "Optional": true,
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "health_check_type": {
+        "Type": "TypeString",
+        "Optional": true,
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "instances": {
+        "Type": "TypeInt",
+        "Optional": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "memory": {
+        "Type": "TypeInt",
+        "Optional": true,
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "name": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "ports": {
+        "Type": "TypeSet",
+        "Optional": true,
+        "Computed": true,
+        "Default": {},
+        "Elem": {
+          "Type": "SchemaElements",
+          "ElementsType": "TypeInt"
+        }
+      },
+      "route": {
+        "Type": "TypeList",
+        "Optional": true,
+        "MaxItems": 1,
+        "Default": {},
+        "Elem": {
+          "Type": "SchemaInfo",
+          "Info": {
+            "default_route": {
+              "Type": "TypeString",
+              "Optional": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "default_route_mapping_id": {
+              "Type": "TypeString",
+              "Computed": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "live_route": {
+              "Type": "TypeString",
+              "Optional": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "live_route_mapping_id": {
+              "Type": "TypeString",
+              "Computed": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "stage_route": {
+              "Type": "TypeString",
+              "Optional": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "stage_route_mapping_id": {
+              "Type": "TypeString",
+              "Computed": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "validation_script": {
+              "Type": "TypeString",
+              "Optional": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "version": {
+              "Type": "TypeString",
+              "Optional": true,
+              "Default": {},
+              "Elem": {}
+            }
+          }
+        }
+      },
+      "service_binding": {
+        "Type": "TypeList",
+        "Optional": true,
+        "Default": {},
+        "Elem": {
+          "Type": "SchemaInfo",
+          "Info": {
+            "binding_id": {
+              "Type": "TypeString",
+              "Computed": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "credentials": {
+              "Type": "TypeMap",
+              "Computed": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "params": {
+              "Type": "TypeMap",
+              "Optional": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "service_instance": {
+              "Type": "TypeString",
+              "Required": true,
+              "Default": {},
+              "Elem": {}
+            }
+          }
+        }
+      },
+      "space": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "stack": {
+        "Type": "TypeString",
+        "Optional": true,
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "stopped": {
+        "Type": "TypeBool",
+        "Optional": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "timeout": {
+        "Type": "TypeInt",
+        "Optional": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "url": {
+        "Type": "TypeString",
+        "Optional": true,
+        "ConflictsWith": [
+          "git",
+          "github_release"
+        ],
+        "Default": {},
+        "Elem": {}
+      }
+    },
+    "cf_asg": {
+      "name": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "rule": {
+        "Type": "TypeList",
+        "Required": true,
+        "Default": {},
+        "Elem": {
+          "Type": "SchemaInfo",
+          "Info": {
+            "code": {
+              "Type": "TypeInt",
+              "Optional": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "description": {
+              "Type": "TypeString",
+              "Optional": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "destination": {
+              "Type": "TypeString",
+              "Required": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "log": {
+              "Type": "TypeBool",
+              "Optional": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "ports": {
+              "Type": "TypeString",
+              "Optional": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "protocol": {
+              "Type": "TypeString",
+              "Required": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "type": {
+              "Type": "TypeInt",
+              "Optional": true,
+              "Default": {},
+              "Elem": {}
+            }
+          }
+        }
+      }
+    },
+    "cf_buildpack": {
+      "enabled": {
+        "Type": "TypeBool",
+        "Optional": true,
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "git": {
+        "Type": "TypeList",
+        "Optional": true,
+        "MaxItems": 1,
+        "ConflictsWith": [
+          "url",
+          "github_release"
+        ],
+        "Default": {},
+        "Elem": {
+          "Type": "SchemaInfo",
+          "Info": {
+            "branch": {
+              "Type": "TypeString",
+              "Optional": true,
+              "ConflictsWith": [
+                "git.tag"
+              ],
+              "Default": {},
+              "Elem": {}
+            },
+            "key": {
+              "Type": "TypeString",
+              "Optional": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "password": {
+              "Type": "TypeString",
+              "Optional": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "tag": {
+              "Type": "TypeString",
+              "Optional": true,
+              "ConflictsWith": [
+                "git.branch"
+              ],
+              "Default": {},
+              "Elem": {}
+            },
+            "url": {
+              "Type": "TypeString",
+              "Required": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "user": {
+              "Type": "TypeString",
+              "Optional": true,
+              "Default": {},
+              "Elem": {}
+            }
+          }
+        }
+      },
+      "github_release": {
+        "Type": "TypeList",
+        "Optional": true,
+        "MaxItems": 1,
+        "ConflictsWith": [
+          "url",
+          "git"
+        ],
+        "Default": {},
+        "Elem": {
+          "Type": "SchemaInfo",
+          "Info": {
+            "filename": {
+              "Type": "TypeString",
+              "Required": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "owner": {
+              "Type": "TypeString",
+              "Required": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "repo": {
+              "Type": "TypeString",
+              "Required": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "token": {
+              "Type": "TypeString",
+              "Optional": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "version": {
+              "Type": "TypeString",
+              "Required": true,
+              "Default": {},
+              "Elem": {}
+            }
+          }
+        }
+      },
+      "locked": {
+        "Type": "TypeBool",
+        "Optional": true,
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "name": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "position": {
+        "Type": "TypeInt",
+        "Optional": true,
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "url": {
+        "Type": "TypeString",
+        "Optional": true,
+        "ConflictsWith": [
+          "git",
+          "github_release"
+        ],
+        "Default": {},
+        "Elem": {}
+      }
+    },
+    "cf_config": {
+      "feature_flags": {
+        "Type": "TypeList",
+        "Optional": true,
+        "MaxItems": 1,
+        "Default": {},
+        "Elem": {
+          "Type": "SchemaInfo",
+          "Info": {
+            "app_bits_upload": {
+              "Type": "TypeString",
+              "Optional": true,
+              "Computed": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "app_scaling": {
+              "Type": "TypeString",
+              "Optional": true,
+              "Computed": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "diego_docker": {
+              "Type": "TypeString",
+              "Optional": true,
+              "Computed": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "env_var_visibility": {
+              "Type": "TypeString",
+              "Optional": true,
+              "Computed": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "private_domain_creation": {
+              "Type": "TypeString",
+              "Optional": true,
+              "Computed": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "route_creation": {
+              "Type": "TypeString",
+              "Optional": true,
+              "Computed": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "service_instance_creation": {
+              "Type": "TypeString",
+              "Optional": true,
+              "Computed": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "set_roles_by_username": {
+              "Type": "TypeString",
+              "Optional": true,
+              "Computed": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "space_developer_env_var_visibility": {
+              "Type": "TypeString",
+              "Optional": true,
+              "Computed": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "space_scoped_private_broker_creation": {
+              "Type": "TypeString",
+              "Optional": true,
+              "Computed": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "task_creation": {
+              "Type": "TypeString",
+              "Optional": true,
+              "Computed": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "unset_roles_by_username": {
+              "Type": "TypeString",
+              "Optional": true,
+              "Computed": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "user_org_creation": {
+              "Type": "TypeString",
+              "Optional": true,
+              "Computed": true,
+              "Default": {},
+              "Elem": {}
+            }
+          }
+        }
+      }
+    },
+    "cf_default_asg": {
+      "asgs": {
+        "Type": "TypeSet",
+        "Required": true,
+        "Default": {},
+        "Elem": {
+          "Type": "SchemaElements",
+          "ElementsType": "TypeString"
+        }
+      },
+      "name": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      }
+    },
+    "cf_domain": {
+      "domain": {
+        "Type": "TypeString",
+        "Optional": true,
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "name": {
+        "Type": "TypeString",
+        "Optional": true,
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "org": {
+        "Type": "TypeString",
+        "Optional": true,
+        "ConflictsWith": [
+          "router_group"
+        ],
+        "Default": {},
+        "Elem": {}
+      },
+      "router_group": {
+        "Type": "TypeString",
+        "Optional": true,
+        "ConflictsWith": [
+          "org"
+        ],
+        "Default": {},
+        "Elem": {}
+      },
+      "router_type": {
+        "Type": "TypeString",
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "sub_domain": {
+        "Type": "TypeString",
+        "Optional": true,
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      }
+    },
+    "cf_evg": {
+      "name": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "variables": {
+        "Type": "TypeMap",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      }
+    },
+    "cf_org": {
+      "auditors": {
+        "Type": "TypeSet",
+        "Optional": true,
+        "Default": {},
+        "Elem": {
+          "Type": "SchemaElements",
+          "ElementsType": "TypeString"
+        }
+      },
+      "billing_managers": {
+        "Type": "TypeSet",
+        "Optional": true,
+        "Default": {},
+        "Elem": {
+          "Type": "SchemaElements",
+          "ElementsType": "TypeString"
+        }
+      },
+      "managers": {
+        "Type": "TypeSet",
+        "Optional": true,
+        "Default": {},
+        "Elem": {
+          "Type": "SchemaElements",
+          "ElementsType": "TypeString"
+        }
+      },
+      "name": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "quota": {
+        "Type": "TypeString",
+        "Optional": true,
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      }
+    },
+    "cf_quota": {
+      "allow_paid_service_plans": {
+        "Type": "TypeBool",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "instance_memory": {
+        "Type": "TypeInt",
+        "Optional": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "name": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "org": {
+        "Type": "TypeString",
+        "Optional": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "total_app_instances": {
+        "Type": "TypeInt",
+        "Optional": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "total_memory": {
+        "Type": "TypeInt",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "total_private_domains": {
+        "Type": "TypeInt",
+        "Optional": true,
+        "ConflictsWith": [
+          "org"
+        ],
+        "Default": {},
+        "Elem": {}
+      },
+      "total_route_ports": {
+        "Type": "TypeInt",
+        "Optional": true,
+        "ConflictsWith": [
+          "org"
+        ],
+        "Default": {},
+        "Elem": {}
+      },
+      "total_routes": {
+        "Type": "TypeInt",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "total_services": {
+        "Type": "TypeInt",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      }
+    },
+    "cf_route": {
+      "domain": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "endpoint": {
+        "Type": "TypeString",
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "hostname": {
+        "Type": "TypeString",
+        "Optional": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "path": {
+        "Type": "TypeString",
+        "Optional": true,
+        "ConflictsWith": [
+          "port"
+        ],
+        "Default": {},
+        "Elem": {}
+      },
+      "port": {
+        "Type": "TypeInt",
+        "Optional": true,
+        "ConflictsWith": [
+          "path",
+          "random_port"
+        ],
+        "Default": {},
+        "Elem": {}
+      },
+      "random_port": {
+        "Type": "TypeBool",
+        "Optional": true,
+        "ConflictsWith": [
+          "path",
+          "port"
+        ],
+        "Default": {},
+        "Elem": {}
+      },
+      "space": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "target": {
+        "Type": "TypeSet",
+        "Optional": true,
+        "Default": {},
+        "Elem": {
+          "Type": "SchemaInfo",
+          "Info": {
+            "app": {
+              "Type": "TypeString",
+              "Required": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "mapping_id": {
+              "Type": "TypeString",
+              "Computed": true,
+              "Default": {},
+              "Elem": {}
+            },
+            "port": {
+              "Type": "TypeInt",
+              "Optional": true,
+              "Default": {},
+              "Elem": {}
+            }
+          }
+        }
+      }
+    },
+    "cf_service_access": {
+      "org": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "plan": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      }
+    },
+    "cf_service_broker": {
+      "name": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "password": {
+        "Type": "TypeString",
+        "Optional": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "service_plans": {
+        "Type": "TypeMap",
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "space": {
+        "Type": "TypeString",
+        "Optional": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "url": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "username": {
+        "Type": "TypeString",
+        "Optional": true,
+        "Default": {},
+        "Elem": {}
+      }
+    },
+    "cf_service_instance": {
+      "json_params": {
+        "Type": "TypeString",
+        "Optional": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "name": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "service_plan": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "space": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "tags": {
+        "Type": "TypeList",
+        "Optional": true,
+        "Default": {},
+        "Elem": {
+          "Type": "SchemaElements",
+          "ElementsType": "TypeString"
+        }
+      }
+    },
+    "cf_service_key": {
+      "credentials": {
+        "Type": "TypeMap",
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "name": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "params": {
+        "Type": "TypeMap",
+        "Optional": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "service_instance": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      }
+    },
+    "cf_space": {
+      "allow_ssh": {
+        "Type": "TypeBool",
+        "Optional": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "asgs": {
+        "Type": "TypeSet",
+        "Optional": true,
+        "Default": {},
+        "Elem": {
+          "Type": "SchemaElements",
+          "ElementsType": "TypeString"
+        }
+      },
+      "auditors": {
+        "Type": "TypeSet",
+        "Optional": true,
+        "Default": {},
+        "Elem": {
+          "Type": "SchemaElements",
+          "ElementsType": "TypeString"
+        }
+      },
+      "developers": {
+        "Type": "TypeSet",
+        "Optional": true,
+        "Default": {},
+        "Elem": {
+          "Type": "SchemaElements",
+          "ElementsType": "TypeString"
+        }
+      },
+      "managers": {
+        "Type": "TypeSet",
+        "Optional": true,
+        "Default": {},
+        "Elem": {
+          "Type": "SchemaElements",
+          "ElementsType": "TypeString"
+        }
+      },
+      "name": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "org": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "quota": {
+        "Type": "TypeString",
+        "Optional": true,
+        "Default": {},
+        "Elem": {}
+      }
+    },
+    "cf_user": {
+      "email": {
+        "Type": "TypeString",
+        "Optional": true,
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "family_name": {
+        "Type": "TypeString",
+        "Optional": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "given_name": {
+        "Type": "TypeString",
+        "Optional": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "groups": {
+        "Type": "TypeSet",
+        "Optional": true,
+        "Default": {},
+        "Elem": {
+          "Type": "SchemaElements",
+          "ElementsType": "TypeString"
+        }
+      },
+      "name": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "origin": {
+        "Type": "TypeString",
+        "Optional": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "password": {
+        "Type": "TypeString",
+        "Optional": true,
+        "Default": {},
+        "Elem": {}
+      }
+    },
+    "cf_user_provided_service": {
+      "credentials": {
+        "Type": "TypeMap",
+        "Optional": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "name": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "routeServiceURL": {
+        "Type": "TypeString",
+        "Optional": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "space": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "syslogDrainURL": {
+        "Type": "TypeString",
+        "Optional": true,
+        "Default": {},
+        "Elem": {}
+      }
+    }
+  },
+  "data-sources": {
+    "cf_asg": {
+      "name": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      }
+    },
+    "cf_domain": {
+      "domain": {
+        "Type": "TypeString",
+        "Optional": true,
+        "Computed": true,
+        "ConflictsWith": [
+          "name"
+        ],
+        "Default": {},
+        "Elem": {}
+      },
+      "name": {
+        "Type": "TypeString",
+        "Optional": true,
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "org": {
+        "Type": "TypeString",
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "sub_domain": {
+        "Type": "TypeString",
+        "Optional": true,
+        "ConflictsWith": [
+          "name"
+        ],
+        "Default": {},
+        "Elem": {}
+      }
+    },
+    "cf_info": {
+      "api_endpoint": {
+        "Type": "TypeString",
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "api_version": {
+        "Type": "TypeString",
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "auth_endpoint": {
+        "Type": "TypeString",
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "doppler_endpoint": {
+        "Type": "TypeString",
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "logging_endpoint": {
+        "Type": "TypeString",
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "password": {
+        "Type": "TypeString",
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "routing_endpoint": {
+        "Type": "TypeString",
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "skip_ssl_validation": {
+        "Type": "TypeString",
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "uaa_endpoint": {
+        "Type": "TypeString",
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "user": {
+        "Type": "TypeString",
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      }
+    },
+    "cf_org": {
+      "name": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      }
+    },
+    "cf_quota": {
+      "name": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "org": {
+        "Type": "TypeString",
+        "Optional": true,
+        "Default": {},
+        "Elem": {}
+      }
+    },
+    "cf_router_group": {
+      "name": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "type": {
+        "Type": "TypeString",
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      }
+    },
+    "cf_service": {
+      "name": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "service_plans": {
+        "Type": "TypeMap",
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "space": {
+        "Type": "TypeString",
+        "Optional": true,
+        "Default": {},
+        "Elem": {}
+      }
+    },
+    "cf_space": {
+      "name": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "org": {
+        "Type": "TypeString",
+        "Optional": true,
+        "Computed": true,
+        "ConflictsWith": [
+          "org_name"
+        ],
+        "Default": {},
+        "Elem": {}
+      },
+      "org_name": {
+        "Type": "TypeString",
+        "Optional": true,
+        "Computed": true,
+        "ConflictsWith": [
+          "org"
+        ],
+        "Default": {},
+        "Elem": {}
+      },
+      "quota": {
+        "Type": "TypeString",
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      }
+    },
+    "cf_stack": {
+      "description": {
+        "Type": "TypeString",
+        "Computed": true,
+        "Default": {},
+        "Elem": {}
+      },
+      "name": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      }
+    },
+    "cf_user": {
+      "name": {
+        "Type": "TypeString",
+        "Required": true,
+        "Default": {},
+        "Elem": {}
+      }
+    }
+  }
+}

--- a/generate-schema/generate-schema.go
+++ b/generate-schema/generate-schema.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	tf "github.com/hashicorp/terraform/terraform"
+	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry"
+
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+)
+
+// ExportSchema should be called to export the structure
+// of the provider.
+func Export(p *schema.Provider) *ResourceProviderSchema {
+	result := new(ResourceProviderSchema)
+
+	result.Name = "cf"
+	result.Type = "provider"
+	result.Version = "0.9.5"
+	result.Provider = schemaMap(p.Schema).Export()
+	result.Resources = make(map[string]SchemaInfo)
+	result.DataSources = make(map[string]SchemaInfo)
+
+	for k, r := range p.ResourcesMap {
+		result.Resources[k] = ExportResource(r)
+	}
+	for k, ds := range p.DataSourcesMap {
+		result.DataSources[k] = ExportResource(ds)
+	}
+
+	return result
+}
+
+func ExportResource(r *schema.Resource) SchemaInfo {
+	return schemaMap(r.Schema).Export()
+}
+
+// schemaMap is a wrapper that adds nice functions on top of schemas.
+type schemaMap map[string]*schema.Schema
+
+// Export exports the format of this schema.
+func (m schemaMap) Export() SchemaInfo {
+	result := make(SchemaInfo)
+	for k, v := range m {
+		item := export(v)
+		result[k] = item
+	}
+	return result
+}
+
+func export(v *schema.Schema) SchemaDefinition {
+	item := SchemaDefinition{}
+
+	item.Type = fmt.Sprintf("%s", v.Type)
+	item.Optional = v.Optional
+	item.Required = v.Required
+	item.Description = v.Description
+	item.InputDefault = v.InputDefault
+	item.Computed = v.Computed
+	item.MaxItems = v.MaxItems
+	item.MinItems = v.MinItems
+	item.PromoteSingle = v.PromoteSingle
+	item.ComputedWhen = v.ComputedWhen
+	item.ConflictsWith = v.ConflictsWith
+	item.Deprecated = v.Deprecated
+	item.Removed = v.Removed
+
+	if v.Elem != nil {
+		item.Elem = exportValue(v.Elem, fmt.Sprintf("%T", v.Elem))
+	}
+
+	// TODO: Find better solution
+	if defValue, err := v.DefaultValue(); err == nil && defValue != nil && !reflect.DeepEqual(defValue, v.Default) {
+		item.Default = exportValue(defValue, fmt.Sprintf("%T", defValue))
+	}
+	return item
+}
+
+func exportValue(value interface{}, t string) SchemaElement {
+	s2, ok := value.(*schema.Schema)
+	if ok {
+		return SchemaElement{Type: "SchemaElements", ElementsType: fmt.Sprintf("%s", s2.Type)}
+	}
+	r2, ok := value.(*schema.Resource)
+	if ok {
+		return SchemaElement{Type: "SchemaInfo", Info: ExportResource(r2)}
+	}
+	return SchemaElement{Type: t, Value: fmt.Sprintf("%v", value)}
+}
+
+func Generate(provider *schema.Provider, name string, outputPath string) {
+	outputFilePath := filepath.Join(outputPath, fmt.Sprintf("%s.json", name))
+
+	if err := DoGenerate(provider, name, outputFilePath); err != nil {
+		fmt.Fprintln(os.Stderr, "Error: ", err.Error())
+		os.Exit(255)
+	}
+}
+
+func DoGenerate(provider *schema.Provider, providerName string, outputFilePath string) error {
+	providerJson, err := json.MarshalIndent(Export(provider), "", "  ")
+
+	if err != nil {
+		return err
+	}
+
+	file, err := os.Create(outputFilePath)
+	if err != nil {
+		return err
+	}
+
+	defer file.Close()
+
+	_, err = file.Write(providerJson)
+	if err != nil {
+		return err
+	}
+
+	return file.Sync()
+}
+
+type SchemaElement struct {
+	// One of ValueType or "SchemaElements" or "SchemaInfo"
+	Type string `json:",omitempty"`
+	// Set for simple types (from ValueType)
+	Value string `json:",omitempty"`
+	// Set if Type == "SchemaElements"
+	ElementsType string `json:",omitempty"`
+	// Set if Type == "SchemaInfo"
+	Info SchemaInfo `json:",omitempty"`
+}
+
+type SchemaDefinition struct {
+	Type          string `json:",omitempty"`
+	Optional      bool   `json:",omitempty"`
+	Required      bool   `json:",omitempty"`
+	Description   string `json:",omitempty"`
+	InputDefault  string `json:",omitempty"`
+	Computed      bool   `json:",omitempty"`
+	MaxItems      int    `json:",omitempty"`
+	MinItems      int    `json:",omitempty"`
+	PromoteSingle bool   `json:",omitempty"`
+
+	ComputedWhen  []string `json:",omitempty"`
+	ConflictsWith []string `json:",omitempty"`
+
+	Deprecated string `json:",omitempty"`
+	Removed    string `json:",omitempty"`
+
+	Default SchemaElement `json:",omitempty"`
+	Elem    SchemaElement `json:",omitempty"`
+}
+
+type SchemaInfo map[string]SchemaDefinition
+
+// ResourceProviderSchema
+type ResourceProviderSchema struct {
+	Name        string                `json:"name"`
+	Type        string                `json:"type"`
+	Version     string                `json:"version"`
+	Provider    SchemaInfo            `json:"provider"`
+	Resources   map[string]SchemaInfo `json:"resources"`
+	DataSources map[string]SchemaInfo `json:"data-sources"`
+}
+
+func main() {
+	var provider tf.ResourceProvider
+	provider = cloudfoundry.Provider()
+	Generate(provider.(*schema.Provider), "cf", "/home/guillaume/public-code/intellij-hcl/schemas-extractor/schemas")
+}


### PR DESCRIPTION
IDE support is key to TF providers adoption, as it provides completion, syntax highlighting for resource names as well as attributes.

This PR adds support for the jetbrains [intellij-hcl](https://github.com/VladRassokhin/intellij-hcl) plugin. 

intellij-hcl natively supports completion for official providers by generating meta-data from sources. terraform-provider-cf resources are not yet supported because:
- terraform-provider-cf repo has  not yet been moved to https://github.com/terraform-providers/
- unlike other official providers the source source structure does not match the provider name (`/cloudfoundry` instead of `/cf`)

See more details into https://github.com/VladRassokhin/intellij-hcl/issues/128 

This PR brings a cf.json file that needs to be installed by intellij-hcl  users into ~/.terraform.d/schemas/ on Linux/OSX and %APPDATA%/terraform.d/schemas/ on Windows, and then restart Intellij.

This cf.json file was generated using the following command that should be included into CI, so that next changes to the provider are properly reflected. Once the two root cause above get fixed, then both files can be removed from the source, and leave intellij-hcl builtin schema-generator proceed with updates.

```sh
$ cd terraform-provider-cf
$ go run generate-schema/generate-schema.go cf `pwd`
```

This non official providers seems to adopt this same approach: https://github.com/maxmanuylov/terraform-provider-kubernetes/blob/2269c5e2824a0ba1e0d6677bd43ad385ecdc5180/install.sh#L6
