### PR TITLE
Add imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ website/node_modules
 *.iml
 
 website/vendor
+/terraform-provider-cf
 
 # Test exclusions
 !command/test-fixtures/**/*.tfstate

--- a/cloudfoundry/import_cf_app_test.go
+++ b/cloudfoundry/import_cf_app_test.go
@@ -1,0 +1,42 @@
+package cloudfoundry
+
+import (
+	"testing"
+
+	"fmt"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccApp_importBasic(t *testing.T) {
+	resourceName := "cf_app.spring-music"
+
+	resource.Test(t,
+		resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckAppDestroyed([]string{"spring-music"}),
+			Steps: []resource.TestStep{
+
+				resource.TestStep{
+					Config: fmt.Sprintf(appResourceSpringMusic, defaultAppDomain()),
+				},
+
+				resource.TestStep{
+					ResourceName:      resourceName,
+					ImportState:       true,
+					ImportStateVerify: true,
+					ImportStateVerifyIgnore: []string{
+						"timeout",
+						"route",
+						"url",
+						"service_binding.0.credentials",
+						"service_binding.1.credentials",
+						"buildpack",
+						"command",
+						"health_check_http_endpoint",
+						"health_check_timeout",
+					},
+				},
+			},
+		})
+}

--- a/cloudfoundry/import_cf_asg_test.go
+++ b/cloudfoundry/import_cf_asg_test.go
@@ -1,0 +1,31 @@
+package cloudfoundry
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAsg_importBasic(t *testing.T) {
+	resourceName := "cf_asg.rmq"
+	asgname := "rmq-dev"
+
+	resource.Test(t,
+		resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckASGDestroy(asgname),
+			Steps: []resource.TestStep{
+
+				resource.TestStep{
+					Config: securityGroup,
+				},
+
+				resource.TestStep{
+					ResourceName:      resourceName,
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+}

--- a/cloudfoundry/import_cf_buildpack_test.go
+++ b/cloudfoundry/import_cf_buildpack_test.go
@@ -1,0 +1,31 @@
+package cloudfoundry
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccBuildpack_importBasic(t *testing.T) {
+	resourceName := "cf_buildpack.tomee"
+
+	resource.Test(t,
+		resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckBuildpackDestroyed("tomee-buildpack"),
+			Steps: []resource.TestStep{
+
+				resource.TestStep{
+					Config: buildpackResource,
+				},
+
+				resource.TestStep{
+					ResourceName:            resourceName,
+					ImportState:             true,
+					ImportStateVerify:       true,
+					ImportStateVerifyIgnore: []string{"github_release"},
+				},
+			},
+		})
+}

--- a/cloudfoundry/import_cf_config_test.go
+++ b/cloudfoundry/import_cf_config_test.go
@@ -1,0 +1,30 @@
+package cloudfoundry
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccConfig_importBasic(t *testing.T) {
+	resourceName := "cf_config.ff"
+
+	resource.Test(t,
+		resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckConfigDestroy,
+			Steps: []resource.TestStep{
+
+				resource.TestStep{
+					Config: configResource,
+				},
+
+				resource.TestStep{
+					ResourceName:      resourceName,
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+}

--- a/cloudfoundry/import_cf_default_asg_test.go
+++ b/cloudfoundry/import_cf_default_asg_test.go
@@ -1,0 +1,30 @@
+package cloudfoundry
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDefaultRunningAsg_importBasic(t *testing.T) {
+	resourceName := "cf_default_asg.running"
+
+	resource.Test(t,
+		resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckDefaultRunningAsgDestroy,
+			Steps: []resource.TestStep{
+
+				resource.TestStep{
+					Config: defaultRunningSecurityGroupResource,
+				},
+
+				resource.TestStep{
+					ResourceName:      resourceName,
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+}

--- a/cloudfoundry/import_cf_domain_test.go
+++ b/cloudfoundry/import_cf_domain_test.go
@@ -1,0 +1,32 @@
+package cloudfoundry
+
+import (
+	"testing"
+
+	"fmt"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDomain_importBasic(t *testing.T) {
+	resourceName := "cf_domain.shared"
+	domainname := "dev." + defaultAppDomain()
+
+	resource.Test(t,
+		resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckSharedDomainDestroy(domainname),
+			Steps: []resource.TestStep{
+
+				resource.TestStep{
+					Config: fmt.Sprintf(domainResourceShared, defaultAppDomain()),
+				},
+
+				resource.TestStep{
+					ResourceName:      resourceName,
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+}

--- a/cloudfoundry/import_cf_evg_test.go
+++ b/cloudfoundry/import_cf_evg_test.go
@@ -1,0 +1,31 @@
+package cloudfoundry
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccEvg_importBasic(t *testing.T) {
+	resourceName := "cf_evg.running"
+	name := "running"
+
+	resource.Test(t,
+		resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckEvgDestroy(name),
+			Steps: []resource.TestStep{
+
+				resource.TestStep{
+					Config: evgRunningResource,
+				},
+
+				resource.TestStep{
+					ResourceName:      resourceName,
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+}

--- a/cloudfoundry/import_cf_org_test.go
+++ b/cloudfoundry/import_cf_org_test.go
@@ -1,0 +1,30 @@
+package cloudfoundry
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccOrg_importBasic(t *testing.T) {
+	resourceName := "cf_org.org1"
+
+	resource.Test(t,
+		resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckOrgDestroyed("organization-one-updated"),
+			Steps: []resource.TestStep{
+
+				resource.TestStep{
+					Config: orgResource,
+				},
+
+				resource.TestStep{
+					ResourceName:      resourceName,
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+}

--- a/cloudfoundry/import_cf_quota_test.go
+++ b/cloudfoundry/import_cf_quota_test.go
@@ -1,0 +1,31 @@
+package cloudfoundry
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccQuota_importBasic(t *testing.T) {
+	resourceName := "cf_quota.50g"
+	quotaname := "50g"
+
+	resource.Test(t,
+		resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckQuotaResourceDestroy(quotaname),
+			Steps: []resource.TestStep{
+
+				resource.TestStep{
+					Config: quotaResource,
+				},
+
+				resource.TestStep{
+					ResourceName:      resourceName,
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+}

--- a/cloudfoundry/import_cf_route_test.go
+++ b/cloudfoundry/import_cf_route_test.go
@@ -1,0 +1,31 @@
+package cloudfoundry
+
+import (
+	"testing"
+
+	"fmt"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccRoute_importBasic(t *testing.T) {
+	resourceName := "cf_route.test-app-route"
+
+	resource.Test(t,
+		resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckRouteDestroyed([]string{"test-app-single", "test-app-multi"}, defaultAppDomain()),
+			Steps: []resource.TestStep{
+
+				resource.TestStep{
+					Config: fmt.Sprintf(routeResource, defaultAppDomain()),
+				},
+
+				resource.TestStep{
+					ResourceName:      resourceName,
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+}

--- a/cloudfoundry/import_cf_service_access_test.go
+++ b/cloudfoundry/import_cf_service_access_test.go
@@ -1,0 +1,37 @@
+package cloudfoundry
+
+import (
+	"testing"
+
+	"fmt"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccServiceAccess_importBasic(t *testing.T) {
+	resourceName := "cf_service_access.redis-access"
+
+	user, password := getRedisBrokerCredentials()
+	deleteServiceBroker("p-redis")
+
+	var servicePlanAccessGUID string
+
+	resource.Test(t,
+		resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckServiceAccessDestroyed(servicePlanAccessGUID),
+			Steps: []resource.TestStep{
+
+				resource.TestStep{
+					Config: fmt.Sprintf(saResource,
+						defaultSysDomain(), user, password, defaultPcfDevOrgID()),
+				},
+
+				resource.TestStep{
+					ResourceName:      resourceName,
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+}

--- a/cloudfoundry/import_cf_service_broker_test.go
+++ b/cloudfoundry/import_cf_service_broker_test.go
@@ -1,0 +1,36 @@
+package cloudfoundry
+
+import (
+	"testing"
+
+	"fmt"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccServiceBroker_importBasic(t *testing.T) {
+	resourceName := "cf_service_broker.redis"
+
+	user, password := getRedisBrokerCredentials()
+	deleteServiceBroker("p-redis")
+
+	resource.Test(t,
+		resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckServiceBrokerDestroyed("test-redis"),
+			Steps: []resource.TestStep{
+
+				resource.TestStep{
+					Config: fmt.Sprintf(sbResource,
+						defaultSysDomain(), user, password),
+				},
+
+				resource.TestStep{
+					ResourceName:            resourceName,
+					ImportState:             true,
+					ImportStateVerify:       true,
+					ImportStateVerifyIgnore: []string{"password"},
+				},
+			},
+		})
+}

--- a/cloudfoundry/import_cf_service_instance_test.go
+++ b/cloudfoundry/import_cf_service_instance_test.go
@@ -1,0 +1,66 @@
+package cloudfoundry
+
+import (
+	"testing"
+
+	"code.cloudfoundry.org/cli/cf/errors"
+	"fmt"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+)
+
+func TestAccServiceInstance_importBasic(t *testing.T) {
+	resourceName := "cf_service_instance.mysql"
+
+	resource.Test(t,
+		resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckServiceInstanceDestroyedImportState([]string{"mysql", "mysql-updated"}, resourceName),
+			Steps: []resource.TestStep{
+
+				resource.TestStep{
+					Config: serviceInstanceResourceCreate,
+				},
+
+				resource.TestStep{
+					ResourceName:      resourceName,
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+}
+
+// after checking import state doesn't have data resource space, only the imported service instance.
+// check must use id imported instead of using one found in first state (before importing)
+func testAccCheckServiceInstanceDestroyedImportState(names []string, serviceInstanceResource string) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+
+		session := testAccProvider.Meta().(*cfapi.Session)
+
+		rs, ok := s.RootModule().Resources[serviceInstanceResource]
+		if !ok {
+			return fmt.Errorf("Service instance '%s' not found in terraform state", spaceResource)
+		}
+		spaceId := rs.Primary.Attributes["space"]
+		for _, n := range names {
+
+			session.Log.DebugMessage("checking ServiceInstance is Destroyed %s", n)
+
+			if _, err := session.ServiceManager().FindServiceInstance(n, spaceId); err != nil {
+				switch err.(type) {
+				case *errors.ModelNotFoundError:
+					return nil
+
+				default:
+					break
+				}
+			}
+			return fmt.Errorf("service instance with name '%s' still exists in cloud foundry", n)
+		}
+		return nil
+	}
+}

--- a/cloudfoundry/import_cf_service_key_test.go
+++ b/cloudfoundry/import_cf_service_key_test.go
@@ -1,0 +1,31 @@
+package cloudfoundry
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccServiceKey_importBasic(t *testing.T) {
+	resourceName := "cf_service_key.mysql-key"
+
+	resource.Test(t,
+		resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckServiceKeyDestroyed("mysql-key", "cf_service_instance.mysql"),
+			Steps: []resource.TestStep{
+
+				resource.TestStep{
+					Config: serviceKeyResource,
+				},
+
+				resource.TestStep{
+					ResourceName:            resourceName,
+					ImportState:             true,
+					ImportStateVerify:       true,
+					ImportStateVerifyIgnore: []string{"params"},
+				},
+			},
+		})
+}

--- a/cloudfoundry/import_cf_space.go
+++ b/cloudfoundry/import_cf_space.go
@@ -1,0 +1,21 @@
+package cloudfoundry
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+)
+
+func resourceSpaceImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	session := meta.(*cfapi.Session)
+	if session == nil {
+		return []*schema.ResourceData{}, fmt.Errorf("client is nil")
+	}
+	sm := session.SpaceManager()
+	asgIds, err := sm.ListStagingASGs(d.Id())
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+	d.Set("staging_asgs", asgIds)
+	return ImportStatePassthrough(d, meta)
+}

--- a/cloudfoundry/import_cf_space_test.go
+++ b/cloudfoundry/import_cf_space_test.go
@@ -1,0 +1,41 @@
+package cloudfoundry
+
+import (
+	"testing"
+
+	"fmt"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccSpace_importBasic(t *testing.T) {
+	resourceName := "cf_space.space1"
+
+	toIgnore := []string{"staging_asgs.#"}
+
+	session := testSession()
+	asm := session.ASGManager()
+	secGroup, err := asm.Read("public_networks")
+	if err == nil && secGroup.GUID != "" {
+		toIgnore = append(toIgnore, fmt.Sprintf("staging_asgs.%d", resourceStringHash(secGroup.GUID)))
+	}
+
+	resource.Test(t,
+		resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckSpaceDestroyed("space-one"),
+			Steps: []resource.TestStep{
+
+				resource.TestStep{
+					Config: spaceResource,
+				},
+
+				resource.TestStep{
+					ResourceName:            resourceName,
+					ImportState:             true,
+					ImportStateVerify:       true,
+					ImportStateVerifyIgnore: toIgnore,
+				},
+			},
+		})
+}

--- a/cloudfoundry/import_cf_user_provided_service_test.go
+++ b/cloudfoundry/import_cf_user_provided_service_test.go
@@ -1,0 +1,30 @@
+package cloudfoundry
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccUserProvidedService_importBasic(t *testing.T) {
+	resourceName := "cf_user_provided_service.mq"
+
+	resource.Test(t,
+		resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckUserProvidedServiceDestroyed("mq", "cf_space.space1"),
+			Steps: []resource.TestStep{
+
+				resource.TestStep{
+					Config: userProvidedServiceResourceCreate,
+				},
+
+				resource.TestStep{
+					ResourceName:      resourceName,
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+}

--- a/cloudfoundry/import_cf_user_test.go
+++ b/cloudfoundry/import_cf_user_test.go
@@ -1,0 +1,32 @@
+package cloudfoundry
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccUser_WithGroups_importBasic(t *testing.T) {
+	resourceName := "cf_user.admin-service-user"
+	username := "cf-admin"
+
+	resource.Test(t,
+		resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckUserDestroy(username),
+			Steps: []resource.TestStep{
+
+				resource.TestStep{
+					Config: userResourceWithGroups,
+				},
+
+				resource.TestStep{
+					ResourceName:            resourceName,
+					ImportState:             true,
+					ImportStateVerify:       true,
+					ImportStateVerifyIgnore: []string{"password"},
+				},
+			},
+		})
+}

--- a/cloudfoundry/resource_cf_app.go
+++ b/cloudfoundry/resource_cf_app.go
@@ -27,6 +27,10 @@ func resourceApp() *schema.Resource {
 		Update: resourceAppUpdate,
 		Delete: resourceAppDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: resourceAppImport,
+		},
+
 		Schema: map[string]*schema.Schema{
 
 			"name": &schema.Schema{
@@ -714,37 +718,37 @@ func setAppArguments(app cfapi.CCApp, d *schema.ResourceData) {
 
 	d.Set("name", app.Name)
 	d.Set("space", app.SpaceGUID)
-	if app.Instances != nil {
+	if app.Instances != nil || IsImportState(d) {
 		d.Set("instances", app.Instances)
 	}
-	if app.Memory != nil {
+	if app.Memory != nil || IsImportState(d) {
 		d.Set("memory", app.Memory)
 	}
-	if app.DiskQuota != nil {
+	if app.DiskQuota != nil || IsImportState(d) {
 		d.Set("disk_quota", app.DiskQuota)
 	}
-	if app.StackGUID != nil {
+	if app.StackGUID != nil || IsImportState(d) {
 		d.Set("stack", app.StackGUID)
 	}
-	if app.Buildpack != nil {
+	if app.Buildpack != nil || IsImportState(d) {
 		d.Set("buildpack", app.Buildpack)
 	}
-	if app.Command != nil {
+	if app.Command != nil || IsImportState(d) {
 		d.Set("command", app.Command)
 	}
-	if app.EnableSSH != nil {
+	if app.EnableSSH != nil || IsImportState(d) {
 		d.Set("enable_ssh", app.EnableSSH)
 	}
-	if app.HealthCheckHTTPEndpoint != nil {
+	if app.HealthCheckHTTPEndpoint != nil || IsImportState(d) {
 		d.Set("health_check_http_endpoint", app.HealthCheckHTTPEndpoint)
 	}
-	if app.HealthCheckType != nil {
+	if app.HealthCheckType != nil || IsImportState(d) {
 		d.Set("health_check_type", app.HealthCheckType)
 	}
-	if app.HealthCheckTimeout != nil {
+	if app.HealthCheckTimeout != nil || IsImportState(d) {
 		d.Set("health_check_timeout", app.HealthCheckTimeout)
 	}
-	if app.Environment != nil {
+	if app.Environment != nil || IsImportState(d) {
 		d.Set("environment", app.Environment)
 	}
 

--- a/cloudfoundry/resource_cf_asg.go
+++ b/cloudfoundry/resource_cf_asg.go
@@ -16,6 +16,10 @@ func resourceAsg() *schema.Resource {
 		Update: resourceAsgUpdate,
 		Delete: resourceAsgDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 
 			"name": &schema.Schema{

--- a/cloudfoundry/resource_cf_buildpack.go
+++ b/cloudfoundry/resource_cf_buildpack.go
@@ -17,6 +17,10 @@ func resourceBuildpack() *schema.Resource {
 		Update: resourceBuildpackUpdate,
 		Delete: resourceBuildpackDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 
 			"name": &schema.Schema{

--- a/cloudfoundry/resource_cf_config.go
+++ b/cloudfoundry/resource_cf_config.go
@@ -16,6 +16,13 @@ func resourceConfig() *schema.Resource {
 		Update: resourceConfigUpdate,
 		Delete: resourceConfigDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				d.SetId("config")
+				return ImportStatePassthrough(d, meta)
+			},
+		},
+
 		Schema: map[string]*schema.Schema{
 			"feature_flags": &schema.Schema{
 				Type:     schema.TypeList,

--- a/cloudfoundry/resource_cf_default_asg.go
+++ b/cloudfoundry/resource_cf_default_asg.go
@@ -16,6 +16,13 @@ func resourceDefaultAsg() *schema.Resource {
 		Update: resourceDefaultAsgUpdate,
 		Delete: resourceDefaultAsgDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				d.Set("name", d.Id())
+				return ImportStatePassthrough(d, meta)
+			},
+		},
+
 		Schema: map[string]*schema.Schema{
 
 			"name": &schema.Schema{

--- a/cloudfoundry/resource_cf_domain.go
+++ b/cloudfoundry/resource_cf_domain.go
@@ -16,6 +16,10 @@ func resourceDomain() *schema.Resource {
 		Read:   resourceDomainRead,
 		Delete: resourceDomainDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 
 			"name": &schema.Schema{

--- a/cloudfoundry/resource_cf_evg.go
+++ b/cloudfoundry/resource_cf_evg.go
@@ -16,6 +16,13 @@ func resourceEvg() *schema.Resource {
 		Update: resourceEvgUpdate,
 		Delete: resourceEvgDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				d.Set("name", d.Id())
+				return ImportStatePassthrough(d, meta)
+			},
+		},
+
 		Schema: map[string]*schema.Schema{
 
 			"name": &schema.Schema{

--- a/cloudfoundry/resource_cf_org.go
+++ b/cloudfoundry/resource_cf_org.go
@@ -16,6 +16,10 @@ func resourceOrg() *schema.Resource {
 		Update: resourceOrgUpdate,
 		Delete: resourceOrgDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 
 			"name": &schema.Schema{

--- a/cloudfoundry/resource_cf_quota.go
+++ b/cloudfoundry/resource_cf_quota.go
@@ -16,6 +16,10 @@ func resourceQuota() *schema.Resource {
 		Update: resourceQuotaUpdate,
 		Delete: resourceQuotaDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 
 			"name": &schema.Schema{

--- a/cloudfoundry/resource_cf_route.go
+++ b/cloudfoundry/resource_cf_route.go
@@ -18,6 +18,10 @@ func resourceRoute() *schema.Resource {
 		Update: resourceRouteUpdate,
 		Delete: resourceRouteDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 
 			"domain": &schema.Schema{
@@ -171,7 +175,7 @@ func resourceRouteRead(d *schema.ResourceData, meta interface{}) (err error) {
 		return
 	}
 
-	if _, ok := d.GetOk("target"); ok {
+	if _, ok := d.GetOk("target"); ok || IsImportState(d) {
 		var mappings []map[string]interface{}
 		if mappings, err = rm.ReadRouteMappingsByRoute(id); err != nil {
 			return

--- a/cloudfoundry/resource_cf_service_access.go
+++ b/cloudfoundry/resource_cf_service_access.go
@@ -16,6 +16,10 @@ func resourceServiceAccess() *schema.Resource {
 		Update: resourceServiceAccessUpdate,
 		Delete: resourceServiceAccessDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 
 			"plan": &schema.Schema{

--- a/cloudfoundry/resource_cf_service_broker.go
+++ b/cloudfoundry/resource_cf_service_broker.go
@@ -16,6 +16,10 @@ func resourceServiceBroker() *schema.Resource {
 		Update: resourceServiceBrokerUpdate,
 		Delete: resourceServiceBrokerDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 
 			"name": &schema.Schema{

--- a/cloudfoundry/resource_cf_service_instance.go
+++ b/cloudfoundry/resource_cf_service_instance.go
@@ -18,6 +18,10 @@ func resourceServiceInstance() *schema.Resource {
 		Update: resourceServiceInstanceUpdate,
 		Delete: resourceServiceInstanceDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 
 			"name": &schema.Schema{

--- a/cloudfoundry/resource_cf_service_key.go
+++ b/cloudfoundry/resource_cf_service_key.go
@@ -15,6 +15,10 @@ func resourceServiceKey() *schema.Resource {
 		Read:   resourceServiceKeyRead,
 		Delete: resourceServiceKeyDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 
 			"name": &schema.Schema{

--- a/cloudfoundry/resource_cf_space.go
+++ b/cloudfoundry/resource_cf_space.go
@@ -16,6 +16,10 @@ func resourceSpace() *schema.Resource {
 		Update: resourceSpaceUpdate,
 		Delete: resourceSpaceDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: resourceSpaceImport,
+		},
+
 		Schema: map[string]*schema.Schema{
 
 			"name": &schema.Schema{

--- a/cloudfoundry/resource_cf_space_test.go
+++ b/cloudfoundry/resource_cf_space_test.go
@@ -25,21 +25,21 @@ resource "cf_asg" "svc" {
     }
 }
 resource "cf_asg" "stg1" {
-	name = "app-services"
+	name = "app-services1"
     rule {
         protocol = "all"
         destination = "192.168.101.0/24"
     }
 }
 resource "cf_asg" "stg2" {
-	name = "app-services"
+	name = "app-services2"
     rule {
         protocol = "all"
         destination = "192.168.102.0/24"
     }
 }
 resource "cf_asg" "stg3" {
-	name = "app-services"
+	name = "app-services3"
     rule {
         protocol = "all"
         destination = "192.168.103.0/24"
@@ -114,21 +114,21 @@ resource "cf_asg" "svc" {
     }
 }
 resource "cf_asg" "stg1" {
-	name = "app-services"
+	name = "app-services1"
     rule {
         protocol = "all"
         destination = "192.168.101.0/24"
     }
 }
 resource "cf_asg" "stg2" {
-	name = "app-services"
+	name = "app-services2"
     rule {
         protocol = "all"
         destination = "192.168.102.0/24"
     }
 }
 resource "cf_asg" "stg3" {
-	name = "app-services"
+	name = "app-services3"
     rule {
         protocol = "all"
         destination = "192.168.103.0/24"

--- a/cloudfoundry/resource_cf_user.go
+++ b/cloudfoundry/resource_cf_user.go
@@ -16,6 +16,10 @@ func resourceUser() *schema.Resource {
 		Update: resourceUserUpdate,
 		Delete: resourceUserDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 
 			"name": &schema.Schema{

--- a/cloudfoundry/resource_cf_user_provided_service.go
+++ b/cloudfoundry/resource_cf_user_provided_service.go
@@ -16,6 +16,10 @@ func resourceUserProvidedService() *schema.Resource {
 		Update: resourceUserProvidedServiceUpdate,
 		Delete: resourceUserProvidedServiceDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 
 			"name": &schema.Schema{

--- a/cloudfoundry/utils_terraform.go
+++ b/cloudfoundry/utils_terraform.go
@@ -6,6 +6,8 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
+const importStateKey = "is_import_state"
+
 // getListOfStructs
 func getListOfStructs(v interface{}) []map[string]interface{} {
 	vvv := []map[string]interface{}{}
@@ -146,4 +148,30 @@ func getListChangedSchemaLists(old []interface{}, new []interface{}) (remove []m
 		}
 	}
 	return
+}
+
+// ImportStatePassthrough -
+func ImportStatePassthrough(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	MarkImportState(d)
+	return schema.ImportStatePassthrough(d, meta)
+}
+
+// MarkImportState -
+func MarkImportState(d *schema.ResourceData) {
+	connInfo := d.ConnInfo()
+	if connInfo == nil {
+		connInfo = make(map[string]string)
+	}
+	connInfo[importStateKey] = ""
+	d.SetConnInfo(connInfo)
+}
+
+// IsImportState -
+func IsImportState(d *schema.ResourceData) bool {
+	connInfo := d.ConnInfo()
+	if connInfo == nil {
+		return false
+	}
+	_, ok := connInfo[importStateKey]
+	return ok
 }

--- a/website/docs/r/app.html.markdown
+++ b/website/docs/r/app.html.markdown
@@ -108,3 +108,11 @@ The following attributes are exported along with any defaults for the inputs att
 
 * `id` - The GUID of the application
 
+## Import
+
+The current App can be imported using the `app`, e.g.
+
+```
+$ terraform import cf_app.spring-music a-guid
+```
+

--- a/website/docs/r/asg.html.markdown
+++ b/website/docs/r/asg.html.markdown
@@ -55,3 +55,12 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The GUID of the application security group
+
+## Import
+
+The current Asg can be imported using the `asg`, e.g.
+
+```
+$ terraform import cf_asg.messaging a-guid
+```
+

--- a/website/docs/r/buildpack.html.markdown
+++ b/website/docs/r/buildpack.html.markdown
@@ -61,3 +61,11 @@ One of the following arguments must be declared to locate buildpack source or ar
 The following attributes are exported:
 
 * `id` - The GUID of the organization
+
+## Import
+
+The current Buildpack can be imported using the `buildpack`, e.g.
+
+```
+$ terraform import cf_buildpack.tomee a-guid
+```

--- a/website/docs/r/config.html.markdown
+++ b/website/docs/r/config.html.markdown
@@ -53,3 +53,11 @@ The following arguments are supported:
   - `env_var_visibility` - (Optional) All users can view environment variables. Minimum CC API version: 2.58.
   - `space_scoped_private_broker_creation` - (Optional) Space Developers can create space-scoped private service brokers. Minimum CC API version: 2.58.
   - `space_developer_env_var_visibility` - (Optional) Space Developers can view their v2 environment variables. Org Managers and Space Managers can view their v3 environment variables. Minimum CC API version: 2.58.
+
+## Import
+
+The current Config can be imported using the `config`, e.g.
+
+```
+$ terraform import cf_config.config config
+```

--- a/website/docs/r/default_asg.html.markdown
+++ b/website/docs/r/default_asg.html.markdown
@@ -29,3 +29,11 @@ The following arguments are supported:
 
 * `name` - (Required) This should be one of `running` or `staging`
 * `asgs` - (Required) A list of references to application security groups IDs.
+
+## Import
+
+The current Default Asg can be imported using the `default_asg`, e.g.
+
+```
+$ terraform import cf_default_asg.running <running/staging>
+```

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -53,3 +53,11 @@ The following argument applies only to private domains.
 The following attributes are exported:
 
 * `id` - The GUID of the domain.
+
+## Import
+
+The current Domain can be imported using the `domain`, e.g.
+
+```
+$ terraform import cf_domain.private a-guid
+```

--- a/website/docs/r/evg.html.markdown
+++ b/website/docs/r/evg.html.markdown
@@ -34,3 +34,11 @@ The following arguments are supported:
 
 * `name` - (Required) Either `running` or `staging` to indicate the type of environment variable group to update
 * `variables` - (Required) A map of name-value pairs of environment variables
+
+## Import
+
+The current Evg can be imported using the `evg`, e.g.
+
+```
+$ terraform import cf_evg.private <running/staging>
+```

--- a/website/docs/r/network_policy.html.markdown
+++ b/website/docs/r/network_policy.html.markdown
@@ -49,3 +49,11 @@ The following arguments are supported:
 The following attributes are exported along with any defaults for the inputs attributes.
 
 * `id` - The GUID of the network_policy
+
+## Import
+
+The current Network policy can be imported using the `network_policy`, e.g.
+
+```
+$ terraform import cf_network_policy.my-policy a-guid
+```

--- a/website/docs/r/org.html.markdown
+++ b/website/docs/r/org.html.markdown
@@ -37,3 +37,11 @@ The following attributes are exported:
 
 * `id` - The GUID of the organization
 * `quota` - If a quota is not referenced as an argument then the default quota GUID will be exported 
+
+## Import
+
+The current Organization can be imported using the `org`, e.g.
+
+```
+$ terraform import cf_org.o1 a-guid
+```

--- a/website/docs/r/quota.html.markdown
+++ b/website/docs/r/quota.html.markdown
@@ -63,3 +63,11 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The GUID of the quota
+
+## Import
+
+The current Quota can be imported using the `quota`, e.g.
+
+```
+$ terraform import cf_quota.10g a-guid
+```

--- a/website/docs/r/route.html.markdown
+++ b/website/docs/r/route.html.markdown
@@ -52,3 +52,11 @@ The following attributes are exported along with any defaults for the inputs att
 
 * `id` - The GUID of the route
 * `endpoint` - The complete endpoint with path if set for the route
+
+## Import
+
+The current Route can be imported using the `route`, e.g.
+
+```
+$ terraform import cf_route.default a-guid
+```

--- a/website/docs/r/service_access.html.markdown
+++ b/website/docs/r/service_access.html.markdown
@@ -27,3 +27,11 @@ The following arguments are supported:
 
 * `plan` - (Required) The ID of the service plan to grant access to
 * `org` - (Required) The ID of the Org which should have access to the plan
+
+## Import
+
+The current Service Access can be imported using the `service_access`, e.g.
+
+```
+$ terraform import cf_service_access.org1-mysql-512mb a-guid
+```

--- a/website/docs/r/service_binding.html.markdown
+++ b/website/docs/r/service_binding.html.markdown
@@ -27,3 +27,11 @@ The following arguments are supported:
 
 * `app_instance` - (Required) The ID of the applicaiton instance to bind the service instance to.
 * `services_instance` - (Required) The ID the service instance to bind to the application instance.
+
+## Import
+
+The current Service Binding can be imported using the `service_binding`, e.g.
+
+```
+$ terraform import cf_service_binding.org1-mysql-512mb a-guid
+```

--- a/website/docs/r/service_broker.html.markdown
+++ b/website/docs/r/service_broker.html.markdown
@@ -39,3 +39,11 @@ The following attributes are exported:
 
 * `id` - The GUID of the service broker
 * `service_plans` - Map of service plan GUIDs keyed by service "&lt;service name&gt;/&lt;plan name&gt;"
+
+## Import
+
+The current Service Broker can be imported using the `service_broker`, e.g.
+
+```
+$ terraform import cf_service_broker.mysql a-guid
+```

--- a/website/docs/r/service_instance.html.markdown
+++ b/website/docs/r/service_instance.html.markdown
@@ -41,3 +41,11 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The GUID of the service instance
+
+## Import
+
+The current Service Instance can be imported using the `service_broker`, e.g.
+
+```
+$ terraform import cf_service.redis a-guid
+```

--- a/website/docs/r/service_key.html.markdown
+++ b/website/docs/r/service_key.html.markdown
@@ -25,7 +25,7 @@ resource "cf_service_instance" "redis1" {
   service_plan = "${data.cf_service.redis.service_plans["shared-vm"]}"
 }
 
-resource "cf_service_instance" "redis1-key1" {
+resource "cf_service_key" "redis1-key1" {
   name = "pricing-grid-key1"
   service_instance = "${cf_service_instance.redis.id}
 }
@@ -45,3 +45,11 @@ The following attributes are exported:
 
 * `id` - The GUID of the service instance.
 * `credentials` - Credentials for this service key that can be used to bind to the associated service instance.
+
+## Import
+
+The current Service Key can be imported using the `service_broker`, e.g.
+
+```
+$ terraform import cf_service_key.redis1-key1 a-guid
+```

--- a/website/docs/r/space.html.markdown
+++ b/website/docs/r/space.html.markdown
@@ -55,3 +55,11 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The GUID of the Space
+
+## Import
+
+The current Space can be imported using the `space`, e.g.
+
+```
+$ terraform import cf_space.s1 a-guid
+```

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -47,3 +47,10 @@ The following attributes are exported:
 * `id` - The GUID of the User
 * `email` - If not provided this attributed will be assigned the same value as the `name`, assuming that the username is the user's email address
 
+## Import
+
+The current User can be imported using the `user`, e.g.
+
+```
+$ terraform import cf_user.admin-service-user a-guid
+```

--- a/website/docs/r/user_provided_service.html.markdown
+++ b/website/docs/r/user_provided_service.html.markdown
@@ -41,3 +41,11 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The GUID of the service instance
+
+## Import
+
+The current User Provided Service can be imported using the `user_provided_service`, e.g.
+
+```
+$ terraform import cf_user_provided_service.mq-server a-guid
+```


### PR DESCRIPTION
Allow usage of command `import`, see explanation here: https://www.terraform.io/docs/import/usage.html 

This permit also to do migration from orange-cloudfoundry/terraform-provider-cloudfoundry to terraform-providers/terraform-provider-cf described as follow:
* manually convert the config file from the `terraform-provider-cloudfoundry` resource to `terraform-provider-cf` resources. This can be made easier through IDE completion, see #4
* import CF resources into TF state. For each resource type:
   * Identify current resources and their ids, e.g. ``terraform state list | grep cloudfoundry_domain | xargs -n 1 terraform state show ``
   * Import the resource in TF state (manually for through upcoming [importeability support in terraform-provider-cf](#6)
   * Remove the `terraform-provider-cloudfoundry` resource from tfstate e.g. ``terraform state list | grep cloudfoundry_domain | xargs -n 1 terraform state remove ``

Docs has been updated consequently and all tests are green.