### PR TITLE
[WIP] Make service plans public on cf_service_broker

### DIFF
--- a/cloudfoundry/cfapi/service_manager.go
+++ b/cloudfoundry/cfapi/service_manager.go
@@ -741,3 +741,21 @@ func (sm *ServiceManager) FindServicePlanID(serviceID string, plan string) (id s
 	}
 	return
 }
+
+func (sm *ServiceManager) UpdatePlanVisibility(planID string, state bool) (err error) {
+	path := fmt.Sprintf("/v2/service_plans/%s", planID)
+	request := map[string]bool{
+		"public": state,
+	}
+	jsonBytes, err := json.Marshal(request)
+	if err != nil {
+		return
+	}
+
+	ups := CCServicePlanResource{}
+	err = sm.ccGateway.UpdateResource(sm.apiEndpoint, path, bytes.NewReader(jsonBytes), &ups)
+
+	return
+
+
+}

--- a/cloudfoundry/cfapi/service_manager.go
+++ b/cloudfoundry/cfapi/service_manager.go
@@ -757,5 +757,4 @@ func (sm *ServiceManager) UpdatePlanVisibility(planID string, state bool) (err e
 
 	return
 
-
 }

--- a/cloudfoundry/import_cf_service_broker_test.go
+++ b/cloudfoundry/import_cf_service_broker_test.go
@@ -7,6 +7,16 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
+const sbImportedResource = `
+
+resource "cf_service_broker" "redis" {
+	name = "test-redis"
+	url = "https://redis-broker.%s"
+	username = "%s"
+	password = "%s"
+}
+`
+
 func TestAccServiceBroker_importBasic(t *testing.T) {
 	resourceName := "cf_service_broker.redis"
 
@@ -21,7 +31,7 @@ func TestAccServiceBroker_importBasic(t *testing.T) {
 			Steps: []resource.TestStep{
 
 				resource.TestStep{
-					Config: fmt.Sprintf(sbResource,
+					Config: fmt.Sprintf(sbImportedResource,
 						defaultSysDomain(), user, password),
 				},
 

--- a/cloudfoundry/resource_cf_service_broker.go
+++ b/cloudfoundry/resource_cf_service_broker.go
@@ -1,12 +1,12 @@
 package cloudfoundry
 
 import (
-	"fmt"
 	"encoding/json"
+	"fmt"
 
+	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
-	"github.com/hashicorp/terraform/helper/hashcode"
 )
 
 func resourceServiceBroker() *schema.Resource {
@@ -49,7 +49,7 @@ func resourceServiceBroker() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Set:      hashVisibility,
-				Elem:     &schema.Resource{
+				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"service": &schema.Schema{
 							Type:     schema.TypeString,
@@ -58,13 +58,13 @@ func resourceServiceBroker() *schema.Resource {
 						"public": &schema.Schema{
 							Type:     schema.TypeSet,
 							Optional: true,
-							Elem:     &schema.Schema{ Type: schema.TypeString },
+							Elem:     &schema.Schema{Type: schema.TypeString},
 							Set:      resourceStringHash,
 						},
 						"private": &schema.Schema{
 							Type:     schema.TypeSet,
 							Optional: true,
-							Elem:     &schema.Schema{ Type: schema.TypeString },
+							Elem:     &schema.Schema{Type: schema.TypeString},
 							Set:      resourceStringHash,
 						},
 					},
@@ -209,14 +209,14 @@ func setServicePlans(d *schema.ResourceData, services []cfapi.CCService) {
 }
 
 func updateServicePlanVisibilities(
-	d        *schema.ResourceData,
-	sm       *cfapi.ServiceManager,
+	d *schema.ResourceData,
+	sm *cfapi.ServiceManager,
 	services []cfapi.CCService) (err error) {
 
 	for _, data := range d.Get("visibilities").(*schema.Set).List() {
-		dataService  := data.(map[string]interface{})
-		serviceName  := dataService["service"].(string)
-		publicPlans  := dataService["public"].(*schema.Set).List()
+		dataService := data.(map[string]interface{})
+		serviceName := dataService["service"].(string)
+		publicPlans := dataService["public"].(*schema.Set).List()
 		privatePlans := dataService["private"].(*schema.Set).List()
 
 		// ensure public plans
@@ -246,13 +246,13 @@ func updateServicePlanVisibilities(
 }
 
 func hashVisibilityObj(serviceName string, public, private []string) int {
-	bytes, _ := json.Marshal(struct{
-		Name    string `json:"name"`
+	bytes, _ := json.Marshal(struct {
+		Name    string   `json:"name"`
 		Public  []string `json:"public"`
 		Private []string `json:"private"`
 	}{
-		Name: serviceName,
-		Public: public,
+		Name:    serviceName,
+		Public:  public,
 		Private: private,
 	})
 	return hashcode.String(string(bytes))
@@ -260,8 +260,8 @@ func hashVisibilityObj(serviceName string, public, private []string) int {
 
 func hashVisibility(visibility interface{}) int {
 	v := visibility.(map[string]interface{})
-	name,    _ := v["service"].(string)
-	public,  _ := v["public"]
+	name, _ := v["service"].(string)
+	public, _ := v["public"]
 	private, _ := v["private"]
 	var pub, priv []string
 
@@ -279,9 +279,9 @@ func setServicePlanVisibilities(d *schema.ResourceData, services []cfapi.CCServi
 	var rvisibilities []interface{}
 
 	for _, data := range d.Get("visibilities").(*schema.Set).List() {
-		dataService  := data.(map[string]interface{})
-		serviceName  := dataService["service"].(string)
-		publicPlans  := dataService["public"].(*schema.Set).List()
+		dataService := data.(map[string]interface{})
+		serviceName := dataService["service"].(string)
+		publicPlans := dataService["public"].(*schema.Set).List()
 		privatePlans := dataService["private"].(*schema.Set).List()
 
 		rservice := make(map[string]interface{})
@@ -306,16 +306,15 @@ func setServicePlanVisibilities(d *schema.ResourceData, services []cfapi.CCServi
 		}
 
 		rservice["service"] = serviceName
-		rservice["public"]   = schema.NewSet(resourceStringHash, rpublic)
-		rservice["private"]  = schema.NewSet(resourceStringHash, rprivate)
+		rservice["public"] = schema.NewSet(resourceStringHash, rpublic)
+		rservice["private"] = schema.NewSet(resourceStringHash, rprivate)
 		rvisibilities = append(rvisibilities, rservice)
 	}
 
 	d.Set("visibilities", schema.NewSet(hashVisibility, rvisibilities))
 }
 
-
-func findServicePlan(serviceName, planName string, services []cfapi.CCService) (*cfapi.CCServicePlan) {
+func findServicePlan(serviceName, planName string, services []cfapi.CCService) *cfapi.CCServicePlan {
 	for _, s := range services {
 		if serviceName == s.Label {
 			for _, p := range s.ServicePlans {

--- a/cloudfoundry/resource_cf_service_broker.go
+++ b/cloudfoundry/resource_cf_service_broker.go
@@ -2,9 +2,11 @@ package cloudfoundry
 
 import (
 	"fmt"
+	"encoding/json"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/hashicorp/terraform/helper/hashcode"
 )
 
 func resourceServiceBroker() *schema.Resource {
@@ -43,6 +45,31 @@ func resourceServiceBroker() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"visibilities": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Set:      hashVisibility,
+				Elem:     &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"service": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"public": &schema.Schema{
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem:     &schema.Schema{ Type: schema.TypeString },
+							Set:      resourceStringHash,
+						},
+						"private": &schema.Schema{
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem:     &schema.Schema{ Type: schema.TypeString },
+							Set:      resourceStringHash,
+						},
+					},
+				},
+			},
 			"service_plans": &schema.Schema{
 				Type:     schema.TypeMap,
 				Computed: true,
@@ -64,9 +91,16 @@ func resourceServiceBrokerCreate(d *schema.ResourceData, meta interface{}) (err 
 	if id, err = sm.CreateServiceBroker(name, url, username, password, space); err != nil {
 		return err
 	}
-	if err = readServiceDetail(id, sm, d); err != nil {
-		return err
+
+	var services []cfapi.CCService
+	if services, err = sm.ReadServiceInfo(id); err != nil {
+		return
 	}
+	setServicePlans(d, services)
+	if err = updateServicePlanVisibilities(d, sm, services); err != nil {
+		return
+	}
+
 	session.Log.DebugMessage("Service detail for service broker: %s:\n%# v\n", name, d.Get("service_plans"))
 
 	d.SetId(id)
@@ -82,6 +116,7 @@ func resourceServiceBrokerRead(d *schema.ResourceData, meta interface{}) (err er
 
 	var (
 		serviceBroker cfapi.CCServiceBroker
+		services      []cfapi.CCService
 	)
 
 	sm := session.ServiceManager()
@@ -89,7 +124,7 @@ func resourceServiceBrokerRead(d *schema.ResourceData, meta interface{}) (err er
 		d.SetId("")
 		return
 	}
-	if err = readServiceDetail(d.Id(), sm, d); err != nil {
+	if services, err = sm.ReadServiceInfo(d.Id()); err != nil {
 		d.SetId("")
 		return
 	}
@@ -98,6 +133,8 @@ func resourceServiceBrokerRead(d *schema.ResourceData, meta interface{}) (err er
 	d.Set("url", serviceBroker.BrokerURL)
 	d.Set("username", serviceBroker.AuthUserName)
 	d.Set("space", serviceBroker.SpaceGUID)
+	setServicePlans(d, services)
+	setServicePlanVisibilities(d, services)
 
 	return
 }
@@ -116,12 +153,19 @@ func resourceServiceBrokerUpdate(d *schema.ResourceData, meta interface{}) (err 
 		d.SetId("")
 		return err
 	}
-	if err = readServiceDetail(id, sm, d); err != nil {
-		d.SetId("")
-		return err
-	}
-	session.Log.DebugMessage("Service detail for service broker: %s:\n%# v\n", name, d.Get("service_plans"))
 
+	var services []cfapi.CCService
+	if services, err = sm.ReadServiceInfo(d.Id()); err != nil {
+		d.SetId("")
+		return
+	}
+
+	if err = updateServicePlanVisibilities(d, sm, services); err != nil {
+		return
+	}
+	setServicePlans(d, services)
+
+	session.Log.DebugMessage("Service detail for service broker: %s:\n%# v\n", name, d.Get("service_plans"))
 	return
 }
 
@@ -154,23 +198,132 @@ func getSchemaAttributes(d *schema.ResourceData) (id, name, url, username, passw
 	return
 }
 
-func readServiceDetail(id string, sm *cfapi.ServiceManager, d *schema.ResourceData) (err error) {
-
-	var (
-		services []cfapi.CCService
-	)
-
-	if services, err = sm.ReadServiceInfo(id); err != nil {
-		return
-	}
-
+func setServicePlans(d *schema.ResourceData, services []cfapi.CCService) {
 	servicePlans := make(map[string]interface{})
 	for _, s := range services {
-		for _, sp := range s.ServicePlans {
-			servicePlans[s.Label+"/"+sp.Name] = sp.ID
+		for _, p := range s.ServicePlans {
+			servicePlans[s.Label+"/"+p.Name] = p.ID
 		}
 	}
 	d.Set("service_plans", servicePlans)
+}
 
+func updateServicePlanVisibilities(
+	d        *schema.ResourceData,
+	sm       *cfapi.ServiceManager,
+	services []cfapi.CCService) (err error) {
+
+	for _, data := range d.Get("visibilities").(*schema.Set).List() {
+		dataService  := data.(map[string]interface{})
+		serviceName  := dataService["service"].(string)
+		publicPlans  := dataService["public"].(*schema.Set).List()
+		privatePlans := dataService["private"].(*schema.Set).List()
+
+		// ensure public plans
+		for _, pp := range publicPlans {
+			ppName := pp.(string)
+			plan := findServicePlan(serviceName, ppName, services)
+			if (plan != nil) && (plan.Public != true) {
+				if err = sm.UpdatePlanVisibility(plan.ID, true); err != nil {
+					return
+				}
+			}
+		}
+
+		// ensure private plans
+		for _, pp := range privatePlans {
+			ppName := pp.(string)
+			plan := findServicePlan(serviceName, ppName, services)
+			if (plan != nil) && (plan.Public != false) {
+				if err = sm.UpdatePlanVisibility(plan.ID, false); err != nil {
+					return
+				}
+			}
+		}
+
+	}
 	return
+}
+
+func hashVisibilityObj(serviceName string, public, private []string) int {
+	bytes, _ := json.Marshal(struct{
+		Name    string `json:"name"`
+		Public  []string `json:"public"`
+		Private []string `json:"private"`
+	}{
+		Name: serviceName,
+		Public: public,
+		Private: private,
+	})
+	return hashcode.String(string(bytes))
+}
+
+func hashVisibility(visibility interface{}) int {
+	v := visibility.(map[string]interface{})
+	name,    _ := v["service"].(string)
+	public,  _ := v["public"]
+	private, _ := v["private"]
+	var pub, priv []string
+
+	for _, p := range public.(*schema.Set).List() {
+		pub = append(pub, p.(string))
+	}
+
+	for _, p := range private.(*schema.Set).List() {
+		priv = append(priv, p.(string))
+	}
+	return hashVisibilityObj(name, pub, priv)
+}
+
+func setServicePlanVisibilities(d *schema.ResourceData, services []cfapi.CCService) {
+	var rvisibilities []interface{}
+
+	for _, data := range d.Get("visibilities").(*schema.Set).List() {
+		dataService  := data.(map[string]interface{})
+		serviceName  := dataService["service"].(string)
+		publicPlans  := dataService["public"].(*schema.Set).List()
+		privatePlans := dataService["private"].(*schema.Set).List()
+
+		rservice := make(map[string]interface{})
+		var rpublic, rprivate []interface{}
+
+		// read public plans
+		for _, pp := range publicPlans {
+			ppName := pp.(string)
+			plan := findServicePlan(serviceName, ppName, services)
+			if (plan != nil) && (plan.Public == true) {
+				rpublic = append(rpublic, ppName)
+			}
+		}
+
+		// read private plans
+		for _, pp := range privatePlans {
+			ppName := pp.(string)
+			plan := findServicePlan(serviceName, ppName, services)
+			if (plan != nil) && (plan.Public == false) {
+				rprivate = append(rprivate, ppName)
+			}
+		}
+
+		rservice["service"] = serviceName
+		rservice["public"]   = schema.NewSet(resourceStringHash, rpublic)
+		rservice["private"]  = schema.NewSet(resourceStringHash, rprivate)
+		rvisibilities = append(rvisibilities, rservice)
+	}
+
+	d.Set("visibilities", schema.NewSet(hashVisibility, rvisibilities))
+}
+
+
+func findServicePlan(serviceName, planName string, services []cfapi.CCService) (*cfapi.CCServicePlan) {
+	for _, s := range services {
+		if serviceName == s.Label {
+			for _, p := range s.ServicePlans {
+				if planName == p.Name {
+					return &p
+				}
+			}
+		}
+	}
+	return nil
 }

--- a/cloudfoundry/resource_cf_service_broker_test.go
+++ b/cloudfoundry/resource_cf_service_broker_test.go
@@ -73,19 +73,19 @@ func TestAccServiceBroker_normal(t *testing.T) {
 							ref, "visibilities.#", "1"),
 						resource.TestCheckResourceAttr(
 							ref, fmt.Sprintf("visibilities.%d.service",
-								hashVisibilityObj("p-redis", nil, []string{ "shared-vm" })),
+								hashVisibilityObj("p-redis", nil, []string{"shared-vm"})),
 							"p-redis"),
 						resource.TestCheckResourceAttr(
 							ref, fmt.Sprintf("visibilities.%d.public.#",
-								hashVisibilityObj("p-redis", nil, []string{ "shared-vm" })),
+								hashVisibilityObj("p-redis", nil, []string{"shared-vm"})),
 							"0"),
 						resource.TestCheckResourceAttr(
 							ref, fmt.Sprintf("visibilities.%d.private.#",
-								hashVisibilityObj("p-redis", nil, []string{ "shared-vm" })),
+								hashVisibilityObj("p-redis", nil, []string{"shared-vm"})),
 							"1"),
 						resource.TestCheckResourceAttr(
 							ref, fmt.Sprintf("visibilities.%d.private.%d",
-								hashVisibilityObj("p-redis", nil, []string{ "shared-vm" }),
+								hashVisibilityObj("p-redis", nil, []string{"shared-vm"}),
 								hashcode.String("shared-vm")),
 							"shared-vm"),
 						resource.TestCheckResourceAttrSet(
@@ -104,19 +104,19 @@ func TestAccServiceBroker_normal(t *testing.T) {
 							ref, "visibilities.#", "1"),
 						resource.TestCheckResourceAttr(
 							ref, fmt.Sprintf("visibilities.%d.service",
-								hashVisibilityObj("p-redis", []string{ "shared-vm" }, nil)),
+								hashVisibilityObj("p-redis", []string{"shared-vm"}, nil)),
 							"p-redis"),
 						resource.TestCheckResourceAttr(
 							ref, fmt.Sprintf("visibilities.%d.private.#",
-								hashVisibilityObj("p-redis", []string{ "shared-vm" }, nil)),
+								hashVisibilityObj("p-redis", []string{"shared-vm"}, nil)),
 							"0"),
 						resource.TestCheckResourceAttr(
 							ref, fmt.Sprintf("visibilities.%d.public.#",
-								hashVisibilityObj("p-redis", []string{ "shared-vm" }, nil)),
+								hashVisibilityObj("p-redis", []string{"shared-vm"}, nil)),
 							"1"),
 						resource.TestCheckResourceAttr(
 							ref, fmt.Sprintf("visibilities.%d.public.%d",
-								hashVisibilityObj("p-redis", []string{ "shared-vm" }, nil),
+								hashVisibilityObj("p-redis", []string{"shared-vm"}, nil),
 								hashcode.String("shared-vm")),
 							"shared-vm"),
 					),

--- a/cloudfoundry/resource_cf_service_broker_test.go
+++ b/cloudfoundry/resource_cf_service_broker_test.go
@@ -6,6 +6,7 @@ import (
 
 	"code.cloudfoundry.org/cli/cf/errors"
 
+	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
@@ -18,6 +19,12 @@ resource "cf_service_broker" "redis" {
 	url = "https://redis-broker.%s"
 	username = "%s"
 	password = "%s"
+  visibilities = [
+   {
+     service = "p-redis"
+     private = [ "shared-vm" ]
+   }
+  ]
 }
 `
 
@@ -28,6 +35,12 @@ resource "cf_service_broker" "redis" {
 	url = "https://redis-broker.%s"
 	username = "%s"
 	password = "%s"
+  visibilities = [
+   {
+     service = "p-redis"
+     public  = [ "shared-vm" ]
+   }
+  ]
 }
 `
 
@@ -56,6 +69,25 @@ func TestAccServiceBroker_normal(t *testing.T) {
 							ref, "url", "https://redis-broker."+defaultSysDomain()),
 						resource.TestCheckResourceAttr(
 							ref, "username", "admin"),
+						resource.TestCheckResourceAttr(
+							ref, "visibilities.#", "1"),
+						resource.TestCheckResourceAttr(
+							ref, fmt.Sprintf("visibilities.%d.service",
+								hashVisibilityObj("p-redis", nil, []string{ "shared-vm" })),
+							"p-redis"),
+						resource.TestCheckResourceAttr(
+							ref, fmt.Sprintf("visibilities.%d.public.#",
+								hashVisibilityObj("p-redis", nil, []string{ "shared-vm" })),
+							"0"),
+						resource.TestCheckResourceAttr(
+							ref, fmt.Sprintf("visibilities.%d.private.#",
+								hashVisibilityObj("p-redis", nil, []string{ "shared-vm" })),
+							"1"),
+						resource.TestCheckResourceAttr(
+							ref, fmt.Sprintf("visibilities.%d.private.%d",
+								hashVisibilityObj("p-redis", nil, []string{ "shared-vm" }),
+								hashcode.String("shared-vm")),
+							"shared-vm"),
 						resource.TestCheckResourceAttrSet(
 							ref, "service_plans.p-redis/shared-vm"),
 					),
@@ -68,6 +100,25 @@ func TestAccServiceBroker_normal(t *testing.T) {
 						testAccCheckServiceBrokerExists(ref),
 						resource.TestCheckResourceAttr(
 							ref, "name", "test-redis-renamed"),
+						resource.TestCheckResourceAttr(
+							ref, "visibilities.#", "1"),
+						resource.TestCheckResourceAttr(
+							ref, fmt.Sprintf("visibilities.%d.service",
+								hashVisibilityObj("p-redis", []string{ "shared-vm" }, nil)),
+							"p-redis"),
+						resource.TestCheckResourceAttr(
+							ref, fmt.Sprintf("visibilities.%d.private.#",
+								hashVisibilityObj("p-redis", []string{ "shared-vm" }, nil)),
+							"0"),
+						resource.TestCheckResourceAttr(
+							ref, fmt.Sprintf("visibilities.%d.public.#",
+								hashVisibilityObj("p-redis", []string{ "shared-vm" }, nil)),
+							"1"),
+						resource.TestCheckResourceAttr(
+							ref, fmt.Sprintf("visibilities.%d.public.%d",
+								hashVisibilityObj("p-redis", []string{ "shared-vm" }, nil),
+								hashcode.String("shared-vm")),
+							"shared-vm"),
 					),
 				},
 			},

--- a/website/docs/r/service_broker.html.markdown
+++ b/website/docs/r/service_broker.html.markdown
@@ -16,10 +16,17 @@ The following example creates an service_broker.
 
 ```
 resource "cf_service_broker" "mysql" {
-	name = "test-mysql"
-	url = "http://mysql-broker.local.pcfdev.io"
-	username = "admin"
-	password = "admin"
+  name = "test-mysql"
+  url = "http://mysql-broker.local.pcfdev.io"
+  username = "admin"
+  password = "admin"
+  visibilities = [
+   {
+     service = "p-mysql"
+     public  = [ "512mb" ]
+     private = [ "1gb" ]
+   }
+  ]
 }
 ```
 
@@ -32,6 +39,10 @@ The following arguments are supported:
 * `username` - (Optional) The user name to use to authenticate against the service broker API calls
 * `password` - (Optional) The password to authenticate with
 * `space` - (Optional) The ID of the space to scope this broker to
+* `visibilities` - (Optional, Set) Force public state for some plans of some available services
+  - `service` - (Required, String) The name of targeted service provided by the service broker
+  - `public` - (Optional, List) Plan names that must be set public
+  - `private` - (Optional, List) Plan names that must be set private
 
 ## Attributes Reference
 


### PR DESCRIPTION
When creating a service-broker, service plans are private by default (ie: ```"public" : false``` attribute of ```/v2/service_plans```, which make the service invisible in the marketplace).

The PR propose to add the optional ```visibilities``` attribute to the ```cf_service_broker``` resource. This attribute gives two lists:
  - plans that must be set public
  - plans that must be set private

Any other available plans that don't belong to these lists are unmanaged by terraform and left in their current state.

Because service brokers may offer multiple services, ```visibilities``` attribute is defined as a structured resource where public and private lists are given for each service name.

```
resource "cf_service_broker" "broker1" {
  name = "my-broker"
  url = "https://broker.domain.net"
  username = "user"
  password = "pass"
  visibilities = [
   {
     service = "service1"
     public  = [ "plan1", "plan2" ]
     private  = [ "plan4" ]
   },
   {
     service = "service2"
     public  = [ "plan1"]
   }
  ]
}
```

Do you have any comments or suggestion about the feature itself and/or its implementation ?