### PR TITLE
[WIP] Handle route services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ website/node_modules
 *.iml
 *.test
 *.iml
+.env.json
 
 website/vendor
 /terraform-provider-cf

--- a/cloudfoundry/cfapi/service_manager.go
+++ b/cloudfoundry/cfapi/service_manager.go
@@ -112,6 +112,17 @@ type CCServiceInstanceResource struct {
 	Entity   CCServiceInstance  `json:"entity"`
 }
 
+// CCServiceInstanceRoute -
+type CCServiceInstanceRoute struct {
+	Host            string   `json:"host"`
+}
+
+//  CCServiceInstanceRouteResource -
+type CCServiceInstanceRouteResource struct {
+	Metadata resources.Metadata `json:"metadata"`
+	Entity   CCServiceInstanceRoute  `json:"entity"`
+}
+
 // CCServiceInstanceUpdateRequest -
 type CCServiceInstanceUpdateRequest struct {
 	Name            string                 `json:"name"`
@@ -471,6 +482,46 @@ func (sm *ServiceManager) ReadServiceInstance(serviceInstanceID string) (service
 	serviceInstance = resource.Entity
 	return
 }
+
+// ReadServiceInstanceRoutes -
+func (sm *ServiceManager) ReadServiceInstanceRoutes(serviceInstanceID string) (routes []string, err error) {
+	path := fmt.Sprintf("/v2/service_instances/%s/routes", serviceInstanceID)
+
+	sm.ccGateway.ListPaginatedResources(sm.apiEndpoint, path, CCServiceInstanceRouteResource{}, func(route interface{}) bool {
+		r := route.(CCServiceInstanceRouteResource)
+		routes = append(routes, r.Metadata.GUID)
+		return true
+	})
+
+	return
+}
+
+
+// CreateServiceInstance -
+func (sm *ServiceManager) AddRouteServiceInstance(serviceID, routeID string, params interface{}) (err error) {
+	path := fmt.Sprintf("/v2/service_instances/%s/routes/%s", serviceID, routeID)
+
+	jsonBytes, err := json.Marshal(map[string]interface{}{
+		"parameters" : params,
+	})
+	if err != nil {
+		return
+	}
+
+	resource := CCServiceInstanceResource{}
+	err = sm.ccGateway.UpdateResource(sm.apiEndpoint, path, bytes.NewReader(jsonBytes), &resource)
+	return
+}
+
+
+
+// DeleteRouteServiceInstance -
+func (sm *ServiceManager) DeleteRouteServiceInstance(serviceID, routeID string) (err error) {
+	path := fmt.Sprintf("/v2/service_instances/%s/routes/%s", serviceID, routeID)
+	err = sm.ccGateway.DeleteResource(sm.apiEndpoint, path)
+	return
+}
+
 
 // FindServiceInstance -
 func (sm *ServiceManager) FindServiceInstance(name string, spaceID string) (serviceInstance CCServiceInstance, err error) {

--- a/cloudfoundry/cfapi/service_manager.go
+++ b/cloudfoundry/cfapi/service_manager.go
@@ -114,13 +114,13 @@ type CCServiceInstanceResource struct {
 
 // CCServiceInstanceRoute -
 type CCServiceInstanceRoute struct {
-	Host            string   `json:"host"`
+	Host string `json:"host"`
 }
 
 //  CCServiceInstanceRouteResource -
 type CCServiceInstanceRouteResource struct {
-	Metadata resources.Metadata `json:"metadata"`
-	Entity   CCServiceInstanceRoute  `json:"entity"`
+	Metadata resources.Metadata     `json:"metadata"`
+	Entity   CCServiceInstanceRoute `json:"entity"`
 }
 
 // CCServiceInstanceUpdateRequest -
@@ -496,13 +496,12 @@ func (sm *ServiceManager) ReadServiceInstanceRoutes(serviceInstanceID string) (r
 	return
 }
 
-
 // CreateServiceInstance -
 func (sm *ServiceManager) AddRouteServiceInstance(serviceID, routeID string, params interface{}) (err error) {
 	path := fmt.Sprintf("/v2/service_instances/%s/routes/%s", serviceID, routeID)
 
 	jsonBytes, err := json.Marshal(map[string]interface{}{
-		"parameters" : params,
+		"parameters": params,
 	})
 	if err != nil {
 		return
@@ -513,15 +512,12 @@ func (sm *ServiceManager) AddRouteServiceInstance(serviceID, routeID string, par
 	return
 }
 
-
-
 // DeleteRouteServiceInstance -
 func (sm *ServiceManager) DeleteRouteServiceInstance(serviceID, routeID string) (err error) {
 	path := fmt.Sprintf("/v2/service_instances/%s/routes/%s", serviceID, routeID)
 	err = sm.ccGateway.DeleteResource(sm.apiEndpoint, path)
 	return
 }
-
 
 // FindServiceInstance -
 func (sm *ServiceManager) FindServiceInstance(name string, spaceID string) (serviceInstance CCServiceInstance, err error) {

--- a/cloudfoundry/resource_cf_service_instance_test.go
+++ b/cloudfoundry/resource_cf_service_instance_test.go
@@ -2,8 +2,8 @@ package cloudfoundry
 
 import (
 	"fmt"
-	"testing"
 	"regexp"
+	"testing"
 
 	"code.cloudfoundry.org/cli/cf/errors"
 
@@ -147,7 +147,6 @@ func TestAccServiceInstance_normal(t *testing.T) {
 		})
 }
 
-
 func TestAccRouteServiceInstance_normal(t *testing.T) {
 
 	ref := "cf_service_instance.route-service"
@@ -160,7 +159,7 @@ func TestAccRouteServiceInstance_normal(t *testing.T) {
 			Steps: []resource.TestStep{
 
 				resource.TestStep{
-					Config: fmt.Sprintf(routeServiceInstanceResourceCreate, defaultAppDomain()),
+					Config:      fmt.Sprintf(routeServiceInstanceResourceCreate, defaultAppDomain()),
 					ExpectError: regexp.MustCompile(".*This service does not support route binding.*"),
 				},
 

--- a/website/docs/r/service_instance.html.markdown
+++ b/website/docs/r/service_instance.html.markdown
@@ -12,7 +12,7 @@ Provides a Cloud Foundry resource for managing Cloud Foundry [Service Instances]
 
 ## Example Usage
 
-The following is a Service Instance created within the referenced space and service plan. 
+The following is a Service Instance created within the referenced space and service plan.
 
 ```
 data "cf_service" "redis" {
@@ -32,9 +32,10 @@ The following arguments are supported:
 
 * `name` - (Required, String) The name of the Service Instance in Cloud Foundry
 * `service_plan` - (Required, String) The ID of the [service plan](/docs/providers/cloudfoundry/d/service_plan.html)
-* `space` - (Required, String) The ID of the [space](/docs/providers/cloudfoundry/r/space.html) 
+* `space` - (Required, String) The ID of the [space](/docs/providers/cloudfoundry/r/space.html)
 * `json_params` - (Optional, String) Json string of arbitrary parameters. Some services support providing additional configuration parameters within the provision request
 * `tags` - (Optional, List) List of instance tags. Some services provide a list of tags that Cloud Foundry delivers in [VCAP_SERVICES Env variables](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES)
+* `routes` - (Optional, List) List of route IDs. Add given routes to current [Route Service](https://docs.cloudfoundry.org/services/route-services.html)
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR propose an implementation of Cloud Foundry route services  by adding a ```routes``` attribute to ```cf_service_instance``` resource.

It follows cloud foundry data model. Routes are attached to service instances through ```/v2/service_instances/:service_instance_guid/routes/:route_guid``` [endpoint](http://apidocs.cloudfoundry.org/280/service_instances/binding_a_service_instance_to_a_route.html).


**Example usage:**

```
resource "cf_route" "app-route" {
  domain = "${data.cf_domain.local.id}"
  space = "${data.space.myspace.id}"
  hostname = "my-app"
}

resource "cf_service_instance" "my-route-service" {
  name = "auth-service"
  space = "${data.space.myspace.id}"
  service_plan = "${data.cf_service.auth.service_plans["admin"]}"
  routes = [  "${cf_route.app-route.id}" ]
}
```

<!---
@huboard:{"order":24.007200720024002,"milestone_order":24.007200720024002,"custom_state":""}
-->
