### PR TITLE
[WIP] Allow complex objects in service credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ website/node_modules
 *.iml
 *.test
 *.iml
+.env.json
 
 website/vendor
 /terraform-provider-cf

--- a/cloudfoundry/cfapi/service_manager.go
+++ b/cloudfoundry/cfapi/service_manager.go
@@ -541,7 +541,6 @@ func (sm *ServiceManager) CreateUserProvidedService(name string, spaceID string,
 	return
 }
 
-
 // ExistsUserProvidedService -
 func (sm *ServiceManager) ExistsUserProvidedService(serviceInstanceID string) (found bool, err error) {
 	path := fmt.Sprintf("/v2/user_provided_service_instances")

--- a/cloudfoundry/cfapi/service_manager.go
+++ b/cloudfoundry/cfapi/service_manager.go
@@ -541,6 +541,24 @@ func (sm *ServiceManager) CreateUserProvidedService(name string, spaceID string,
 	return
 }
 
+
+// ExistsUserProvidedService -
+func (sm *ServiceManager) ExistsUserProvidedService(serviceInstanceID string) (found bool, err error) {
+	path := fmt.Sprintf("/v2/user_provided_service_instances")
+	found = false
+	err = sm.ccGateway.ListPaginatedResources(sm.apiEndpoint, path, CCUserProvidedServiceResource{}, func(r interface{}) bool {
+		if s, ok := r.(CCUserProvidedServiceResource); ok {
+			if s.Metadata.GUID == serviceInstanceID {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+
+	return
+}
+
 // ReadUserProvidedService -
 func (sm *ServiceManager) ReadUserProvidedService(serviceInstanceID string) (ups CCUserProvidedService, err error) {
 

--- a/cloudfoundry/resource_cf_app.go
+++ b/cloudfoundry/resource_cf_app.go
@@ -884,6 +884,7 @@ func addServiceBindings(id string, add []map[string]interface{},
 		params = nil
 		if v, ok := b["params"]; ok {
 			vv := v.(map[string]interface{})
+			vv = decodeMapJsonValues(vv)
 			params = &vv
 		}
 		if bindingID, bindingCredentials, err = am.CreateServiceBinding(id, serviceInstanceID, params); err != nil {

--- a/cloudfoundry/resource_cf_service_key.go
+++ b/cloudfoundry/resource_cf_service_key.go
@@ -54,6 +54,7 @@ func resourceServiceKeyCreate(d *schema.ResourceData, meta interface{}) (err err
 	name := d.Get("name").(string)
 	serviceInstance := d.Get("service_instance").(string)
 	params := d.Get("params").(map[string]interface{})
+	params = decodeMapJsonValues(params)
 
 	sm := session.ServiceManager()
 	var serviceKey cfapi.CCServiceKey

--- a/cloudfoundry/resource_cf_service_key_test.go
+++ b/cloudfoundry/resource_cf_service_key_test.go
@@ -37,6 +37,7 @@ resource "cf_service_key" "mysql-key" {
 	params {
 		"key1" = "aaaa"
 		"key2" = "bbbb"
+		"key3" = "{ \"skey1\" : \"cccc\"}"
 	}
 }
 `

--- a/cloudfoundry/resource_cf_user_provided_service.go
+++ b/cloudfoundry/resource_cf_user_provided_service.go
@@ -15,7 +15,7 @@ func resourceUserProvidedService() *schema.Resource {
 		Read:   resourceUserProvidedServiceRead,
 		Update: resourceUserProvidedServiceUpdate,
 		Delete: resourceUserProvidedServiceDelete,
-
+		Exists: resourceUserProvidedServiceExists,
 		Importer: &schema.ResourceImporter{
 			State: ImportStatePassthrough,
 		},
@@ -51,10 +51,23 @@ func resourceUserProvidedService() *schema.Resource {
 			"credentials": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
+				DiffSuppressFunc: diffJsonStrings,
 			},
 		},
 	}
 }
+
+func resourceUserProvidedServiceExists(r *schema.ResourceData, meta interface{}) (found bool, err error) {
+	session := meta.(*cfapi.Session)
+	if session == nil {
+		return false, fmt.Errorf("client is nil")
+	}
+
+	sm := session.ServiceManager()
+	serviceID := r.Id()
+	return sm.ExistsUserProvidedService(serviceID)
+}
+
 
 func resourceUserProvidedServiceCreate(d *schema.ResourceData, meta interface{}) (err error) {
 
@@ -85,6 +98,7 @@ func resourceUserProvidedServiceCreate(d *schema.ResourceData, meta interface{})
 	for k, v := range d.Get("credentials").(map[string]interface{}) {
 		credentials[k] = v.(string)
 	}
+	credentials = decodeMapJsonValues(credentials)
 
 	sm := session.ServiceManager()
 
@@ -131,7 +145,7 @@ func resourceUserProvidedServiceRead(d *schema.ResourceData, meta interface{}) (
 		d.Set("route_service_url", ups.RouteServiceURL)
 	}
 
-	d.Set("credentials", ups.Credentials)
+	d.Set("credentials", encodeMapJsonValues(ups.Credentials))
 
 	session.Log.DebugMessage("Read User Provided Service : %# v", ups)
 
@@ -169,6 +183,7 @@ func resourceUserProvidedServiceUpdate(d *schema.ResourceData, meta interface{})
 	for k, v := range d.Get("credentials").(map[string]interface{}) {
 		credentials[k] = v.(string)
 	}
+	credentials = decodeMapJsonValues(credentials)
 
 	if _, err = sm.UpdateUserProvidedService(id, name, credentials, syslogDrainURL, routeServiceURL); err != nil {
 		return

--- a/cloudfoundry/resource_cf_user_provided_service.go
+++ b/cloudfoundry/resource_cf_user_provided_service.go
@@ -49,8 +49,8 @@ func resourceUserProvidedService() *schema.Resource {
 				Deprecated: "Use route_service_url, Terraform complain about field name may only contain lowercase alphanumeric characters & underscores",
 			},
 			"credentials": &schema.Schema{
-				Type:     schema.TypeMap,
-				Optional: true,
+				Type:             schema.TypeMap,
+				Optional:         true,
 				DiffSuppressFunc: diffJsonStrings,
 			},
 		},
@@ -67,7 +67,6 @@ func resourceUserProvidedServiceExists(r *schema.ResourceData, meta interface{})
 	serviceID := r.Id()
 	return sm.ExistsUserProvidedService(serviceID)
 }
-
 
 func resourceUserProvidedServiceCreate(d *schema.ResourceData, meta interface{}) (err error) {
 

--- a/cloudfoundry/resource_cf_user_provided_service_test.go
+++ b/cloudfoundry/resource_cf_user_provided_service_test.go
@@ -43,6 +43,8 @@ resource "cf_user_provided_service" "mq" {
 		"url" = "mq://localhost:9000"
 		"username" = "user"
 		"password" = "pwd"
+    "json_obj" = "{ \"with\" : { \"complex\" : \"value\" } }"
+    "json_arr" = "[ { \"complex\" : \"value1\" }, { \"complex\" : \"value2\" } ]"
 	}	
 }
 `
@@ -79,6 +81,8 @@ resource "cf_user_provided_service" "mq" {
 		"url" = "mq://localhost:9000"
 		"username" = "new-user"
 		"password" = "new-pwd"
+			"json_obj" = "{ \"with\" : { \"complex\" : \"new-value\" } }"
+			"json_arr" = "[ { \"complex\" : \"value1\" } ]"
 	}
 	syslog_drain_url = "http://localhost/syslog"
 	route_service_url = "https://localhost/route"
@@ -108,6 +112,10 @@ func TestAccUserProvidedService_normal(t *testing.T) {
 							ref, "credentials.username", "user"),
 						resource.TestCheckResourceAttr(
 							ref, "credentials.password", "pwd"),
+						resource.TestCheckResourceAttr(
+							ref, "credentials.json_obj", "{ \"with\" : { \"complex\" : \"value\" } }"),
+						resource.TestCheckResourceAttr(
+							ref, "credentials.json_arr", "[ { \"complex\" : \"value1\" }, { \"complex\" : \"value2\" } ]"),
 						resource.TestCheckNoResourceAttr(
 							ref, "syslog_drain_url"),
 						resource.TestCheckNoResourceAttr(
@@ -129,6 +137,10 @@ func TestAccUserProvidedService_normal(t *testing.T) {
 							ref, "credentials.password", "new-pwd"),
 						resource.TestCheckResourceAttr(
 							ref, "syslog_drain_url", "http://localhost/syslog"),
+						resource.TestCheckResourceAttr(
+							ref, "credentials.json_obj", "{ \"with\" : { \"complex\" : \"new-value\" } }"),
+						resource.TestCheckResourceAttr(
+							ref, "credentials.json_arr", "[ { \"complex\" : \"value1\" } ]"),							
 						resource.TestCheckResourceAttr(
 							ref, "route_service_url", "https://localhost/route"),
 					),

--- a/cloudfoundry/resource_cf_user_provided_service_test.go
+++ b/cloudfoundry/resource_cf_user_provided_service_test.go
@@ -140,7 +140,7 @@ func TestAccUserProvidedService_normal(t *testing.T) {
 						resource.TestCheckResourceAttr(
 							ref, "credentials.json_obj", "{ \"with\" : { \"complex\" : \"new-value\" } }"),
 						resource.TestCheckResourceAttr(
-							ref, "credentials.json_arr", "[ { \"complex\" : \"value1\" } ]"),							
+							ref, "credentials.json_arr", "[ { \"complex\" : \"value1\" } ]"),
 						resource.TestCheckResourceAttr(
 							ref, "route_service_url", "https://localhost/route"),
 					),

--- a/cloudfoundry/utils_strings.go
+++ b/cloudfoundry/utils_strings.go
@@ -1,6 +1,9 @@
 package cloudfoundry
 
-import "github.com/hashicorp/terraform/helper/hashcode"
+import (
+	"encoding/json"
+	"github.com/hashicorp/terraform/helper/hashcode"
+)
 
 // isStringInList -
 func isStringInList(list []string, str string) bool {
@@ -25,4 +28,36 @@ func isStringInInterfaceList(list []interface{}, str string) bool {
 // resourceStringHash -
 func resourceStringHash(v interface{}) int {
 	return hashcode.String(v.(string))
+}
+
+
+// json.Marshal any non-string values found in data
+func encodeMapJsonValues(data map[string]interface{}) (res map[string]interface{}) {
+	res = make(map[string]interface{})
+	for k, v := range data {
+		switch v.(type) {
+		case string:
+			res[k] = v
+		default:
+			b, _ := json.Marshal(v)
+			res[k] = string(b)
+		}
+	}
+	return
+}
+
+// json.Unmarshal all values of data
+func decodeMapJsonValues(data map[string]interface{}) (res map[string]interface{}) {
+	res = make(map[string]interface{})
+	var ival interface{}
+
+	for k, v := range data {
+		value := v.(string)
+		if err := json.Unmarshal([]byte(value), &ival); err == nil {
+			res[k] = ival
+		} else {
+			res[k] = value
+		}
+	}
+	return
 }

--- a/cloudfoundry/utils_strings.go
+++ b/cloudfoundry/utils_strings.go
@@ -30,7 +30,6 @@ func resourceStringHash(v interface{}) int {
 	return hashcode.String(v.(string))
 }
 
-
 // json.Marshal any non-string values found in data
 func encodeMapJsonValues(data map[string]interface{}) (res map[string]interface{}) {
 	res = make(map[string]interface{})

--- a/cloudfoundry/utils_terraform.go
+++ b/cloudfoundry/utils_terraform.go
@@ -1,10 +1,10 @@
 package cloudfoundry
 
 import (
-	"strings"
-	"reflect"
 	"encoding/json"
 	"github.com/hashicorp/terraform/helper/schema"
+	"reflect"
+	"strings"
 )
 
 const importStateKey = "is_import_state"

--- a/cloudfoundry/utils_terraform.go
+++ b/cloudfoundry/utils_terraform.go
@@ -1,8 +1,9 @@
 package cloudfoundry
 
 import (
+	"strings"
 	"reflect"
-
+	"encoding/json"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -175,3 +176,33 @@ func IsImportState(d *schema.ResourceData) bool {
 	_, ok := connInfo[importStateKey]
 	return ok
 }
+
+// Unserialize and serialize values to compare normalized jsons
+func diffJsonStrings(k, old, new string, rd *schema.ResourceData) bool {
+	// Warning: DiffSuppressFunc is called on resource creation. When its value
+	// is computed (eg: value depends on other resource yet to be created), and value
+	// is a map/set/lists, function is called with <key>.% where both 'new' and 'old'
+	// are empty string.
+	//
+	// Squelching this diff leads to terraform panic message :
+	//    diffs didn't match during apply. This is a bug with Terraform and
+	//    should be reported.
+	//
+	if strings.HasSuffix(k, ".%") && old == "" && new == "" {
+		return false
+	}
+
+	var oldi, newi interface{}
+	olde := json.Unmarshal([]byte(old), &oldi)
+	newe := json.Unmarshal([]byte(new), &newi)
+	if olde == nil && newe == nil {
+		oldb, _ := json.Marshal(oldi)
+		newb, _ := json.Marshal(newi)
+		return string(oldb) == string(newb)
+	}
+	return old == new
+}
+
+// Local Variables:
+// ispell-local-dictionary: "american"
+// End:

--- a/website/docs/r/app.html.markdown
+++ b/website/docs/r/app.html.markdown
@@ -77,6 +77,7 @@ Modifying this argument will cause the application to be restaged.
 
   - `service` - (Required, String) The service instance GUID.
   - `params` - (Optional, Map) A list of key/value parameters used by the service broker to create the binding.
+    JSON-encoded string value are parsed to create a structured object.
 
 ### Routing and Blue-Green Deployment Strategy
 

--- a/website/docs/r/service_key.html.markdown
+++ b/website/docs/r/service_key.html.markdown
@@ -38,6 +38,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the Service Key in Cloud Foundry.
 * `service_instance` - (Required) The ID of the Service Instance the key should be associated with.
 * `params` - (Optional, Map) A list of key/value parameters used by the service broker to create the binding for the key.
+  JSON-encoded string value are parsed to create a structured object.
 
 ## Attributes Reference
 

--- a/website/docs/r/user_provided_service.html.markdown
+++ b/website/docs/r/user_provided_service.html.markdown
@@ -22,6 +22,7 @@ resource "cf_user_provided_service" "mq" {
     "url" = "mq://localhost:9000"
     "username" = "admin"
     "password" = "admin"    
+    "ssl_options" = "{ \"verify\" : \"peer\", \"fail_if_no_peer_cert\" : true }"
   }
 }
 ```
@@ -33,6 +34,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the Service Instance in Cloud Foundry
 * `space` - (Required) The ID of the [space](/docs/providers/cloudfoundry/r/space.html) 
 * `credentials` - (Optional) Arbitrary credentials in the form of key-value pairs and delivered to applications via [VCAP_SERVICES Env variables](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES)
+  JSON-encoded string value are parsed to create a structured object.
 * `syslog_drain_url` - (Optional) URL to which logs for bound applications will be streamed
 * `route_service_url` - (Optional) URL to which requests for bound routes will be forwarded. Scheme for this URL must be https
 


### PR DESCRIPTION
### Initial problem

In the present state of the provider, users are limited to flat key/value data in ```credentials``` of ```cf_user_provided_service``` resource while cloud foundry API allows any in-depth structures.

This limit is imposed by the type ```schema.TypeMap``` used in the ```credentials``` attribute that forces ```string``` elements in the map.

### Considered approaches

1. Change ```credentials``` attribute type to ```schema.TypeString``` and parse its JSON content
    - (+) approach used in ```cf_service_instance.json_params```

    - (-) would break backward-compatibility. 
       - Implementing a new attribute and setting the old map as deprecated would eventually force users to an unnecessary migration.

    - (-) would arguably lead to less readable terraform files
       - old style:
         ```
         credentials  {
           host = "localhost"
           port = "8080"
         }
         ```
       - new style:
         ```
         credentials  = <<JSON
           {
             "host" : "localhost",
             "port" : 8080
           }
         JSON
         ```

2. Keep ```schema.TypeMap``` and try a JSON parse on each string elements
    - (+) backward compatible

    - (-) error-prone behaviour
       - the system relies on json validity to tell apart plain strings and json-object
       - when user accidentally gives and invalid json string, the provider can't detect the error

    - (+) a good compromise for terraform file readability
       - sample:
         ```
         credentials  {
           host = "localhost"
           port = "8080"
           extra = <<JSON
           {
              "use_ssl"  : false
           }
           JSON
         }
         ``` 

### The PR

This PR a working proof of concept that implements the second approach. Its purpose is to **initiate the discussions** about the problem more than be merged as it is.

The described problem is present in few existing resources, this PR modifies:
- ```cf_user_provided_service.credentials```
- ```cf_service_key.params```
- ```cf_app.service_bindings.params```

