### PR TITLE
Make service plans public on cf_service_access

### DIFF
--- a/cf.json
+++ b/cf.json
@@ -977,7 +977,7 @@
         }
       }
     },
-    "cf_service_access": {
+    "cf_service_plan_access": {
       "org": {
         "Type": "TypeString",
         "Required": true,

--- a/cloudfoundry/cfapi/service_manager.go
+++ b/cloudfoundry/cfapi/service_manager.go
@@ -408,6 +408,30 @@ func (sm *ServiceManager) DeleteServicePlanAccess(servicePlanAccessGUID string) 
 	return
 }
 
+// UpdatePlanVisibility -
+func (sm *ServiceManager) UpdateServicePlanVisibility(planID string, state bool) (err error) {
+	path := fmt.Sprintf("/v2/service_plans/%s", planID)
+	request := map[string]bool{
+		"public": state,
+	}
+	jsonBytes, err := json.Marshal(request)
+	if err != nil {
+		return
+	}
+
+	ups := CCServicePlanResource{}
+	err = sm.ccGateway.UpdateResource(sm.apiEndpoint, path, bytes.NewReader(jsonBytes), &ups)
+	return
+}
+
+// ReadServicePlan -
+func (sm *ServiceManager) ReadServicePlan(planID string) (CCServicePlan, error) {
+	res := CCServicePlanResource{}
+	url := fmt.Sprintf("%s/v2/service_plans/%s", sm.apiEndpoint, planID)
+	err := sm.ccGateway.GetResource(url, &res)
+	return res.Entity, err
+}
+
 // CreateServiceInstance -
 func (sm *ServiceManager) CreateServiceInstance(name, servicePlanID, spaceID string,
 	params map[string]interface{}, tags []string) (id string, err error) {

--- a/cloudfoundry/import_cf_service_access.go
+++ b/cloudfoundry/import_cf_service_access.go
@@ -1,0 +1,31 @@
+package cloudfoundry
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+)
+
+func resourceServiceAccessImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	session := meta.(*cfapi.Session)
+	if session == nil {
+		return []*schema.ResourceData{}, fmt.Errorf("client is nil")
+	}
+	sm := session.ServiceManager()
+
+	planID, orgID, err := sm.ReadServicePlanAccess(d.Id())
+	if err == nil {
+		d.Set("plan", planID)
+		d.Set("org", orgID)
+		return schema.ImportStatePassthrough(d, meta)
+	}
+
+	plan, err := sm.ReadServicePlan(d.Id())
+	if err == nil {
+		d.Set("plan", d.Id())
+		d.Set("public", plan.Public)
+		return schema.ImportStatePassthrough(d, meta)
+	}
+
+	return []*schema.ResourceData{}, fmt.Errorf("unable to find service_plan_visibilities nor service plan for id '%s'", d.Id())
+}

--- a/cloudfoundry/import_cf_service_plan_access.go
+++ b/cloudfoundry/import_cf_service_plan_access.go
@@ -6,7 +6,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
 )
 
-func resourceServiceAccessImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceServicePlanAccessImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	session := meta.(*cfapi.Session)
 	if session == nil {
 		return []*schema.ResourceData{}, fmt.Errorf("client is nil")

--- a/cloudfoundry/import_cf_service_plan_access_test.go
+++ b/cloudfoundry/import_cf_service_plan_access_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccServiceAccess_importBasic(t *testing.T) {
-	resourceName := "cf_service_access.redis-access"
+func TestAccServicePlanAccess_importBasic(t *testing.T) {
+	resourceName := "cf_service_plan_access.redis-access"
 
 	user, password := getRedisBrokerCredentials()
 	deleteServiceBroker("p-redis")
@@ -19,7 +19,7 @@ func TestAccServiceAccess_importBasic(t *testing.T) {
 		resource.TestCase{
 			PreCheck:     func() { testAccPreCheck(t) },
 			Providers:    testAccProviders,
-			CheckDestroy: testAccCheckServiceAccessDestroyed(servicePlanAccessGUID),
+			CheckDestroy: testAccCheckServicePlanAccessDestroyed(servicePlanAccessGUID),
 			Steps: []resource.TestStep{
 
 				resource.TestStep{

--- a/cloudfoundry/provider.go
+++ b/cloudfoundry/provider.go
@@ -71,7 +71,7 @@ func Provider() terraform.ResourceProvider {
 			"cf_org":                   resourceOrg(),
 			"cf_space":                 resourceSpace(),
 			"cf_service_broker":        resourceServiceBroker(),
-			"cf_service_access":        resourceServiceAccess(),
+			"cf_service_plan_access":   resourceServicePlanAccess(),
 			"cf_service_instance":      resourceServiceInstance(),
 			"cf_service_key":           resourceServiceKey(),
 			"cf_user_provided_service": resourceUserProvidedService(),

--- a/cloudfoundry/resource_cf_service_plan_access.go
+++ b/cloudfoundry/resource_cf_service_plan_access.go
@@ -6,13 +6,13 @@ import (
 	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
 )
 
-func resourceServiceAccess() *schema.Resource {
+func resourceServicePlanAccess() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceServiceAccessCreate,
-		Read:   resourceServiceAccessRead,
-		Delete: resourceServiceAccessDelete,
+		Create: resourceServicePlanAccessCreate,
+		Read:   resourceServicePlanAccessRead,
+		Delete: resourceServicePlanAccessDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceServiceAccessImport,
+			State: resourceServicePlanAccessImport,
 		},
 		Schema: map[string]*schema.Schema{
 			"plan": &schema.Schema{
@@ -36,7 +36,7 @@ func resourceServiceAccess() *schema.Resource {
 	}
 }
 
-func resourceServiceAccessCreate(d *schema.ResourceData, meta interface{}) (err error) {
+func resourceServicePlanAccessCreate(d *schema.ResourceData, meta interface{}) (err error) {
 
 	session := meta.(*cfapi.Session)
 	if session == nil {
@@ -69,7 +69,7 @@ func resourceServiceAccessCreate(d *schema.ResourceData, meta interface{}) (err 
 	return nil
 }
 
-func resourceServiceAccessRead(d *schema.ResourceData, meta interface{}) (err error) {
+func resourceServicePlanAccessRead(d *schema.ResourceData, meta interface{}) (err error) {
 	session := meta.(*cfapi.Session)
 	if session == nil {
 		return fmt.Errorf("client is nil")
@@ -100,7 +100,7 @@ func resourceServiceAccessRead(d *schema.ResourceData, meta interface{}) (err er
 	return nil
 }
 
-func resourceServiceAccessDelete(d *schema.ResourceData, meta interface{}) (err error) {
+func resourceServicePlanAccessDelete(d *schema.ResourceData, meta interface{}) (err error) {
 
 	session := meta.(*cfapi.Session)
 	if session == nil {

--- a/cloudfoundry/resource_cf_service_plan_access_test.go
+++ b/cloudfoundry/resource_cf_service_plan_access_test.go
@@ -17,7 +17,7 @@ resource "cf_service_broker" "redis" {
 	password = "%s"
 }
 
-resource "cf_service_access" "redis-access" {
+resource "cf_service_plan_access" "redis-access" {
 	plan = "${cf_service_broker.redis.service_plans["p-redis/shared-vm"]}"
 	org = "%s"
 }
@@ -31,7 +31,7 @@ resource "cf_service_broker" "redis" {
 	password = "%s"
 }
 
-resource "cf_service_access" "redis-access" {
+resource "cf_service_plan_access" "redis-access" {
 	plan = "${cf_service_broker.redis.service_plans["p-redis/shared-vm"]}"
 	public = true
 }
@@ -45,7 +45,7 @@ resource "cf_service_broker" "redis" {
 	password = "%s"
 }
 
-resource "cf_service_access" "redis-access" {
+resource "cf_service_plan_access" "redis-access" {
 	plan = "${cf_service_broker.redis.service_plans["p-redis/shared-vm"]}"
 	public = false
 }
@@ -59,31 +59,31 @@ resource "cf_service_broker" "redis" {
 	password = "%s"
 }
 
-resource "cf_service_access" "redis-access" {
+resource "cf_service_plan_access" "redis-access" {
 	plan = "${cf_service_broker.redis.service_plans["p-redis/shared-vm"]}"
 	org = "%s"
 	public = true
 }
 `
 
-func TestAccServiceAccess_normal(t *testing.T) {
+func TestAccServicePlanAccess_normal(t *testing.T) {
 	user, password := getRedisBrokerCredentials()
 	deleteServiceBroker("p-redis")
 
 	var servicePlanAccessGUID string
-	ref := "cf_service_access.redis-access"
+	ref := "cf_service_plan_access.redis-access"
 
 	resource.Test(t,
 		resource.TestCase{
 			PreCheck:     func() { testAccPreCheck(t) },
 			Providers:    testAccProviders,
-			CheckDestroy: testAccCheckServiceAccessDestroyed(servicePlanAccessGUID),
+			CheckDestroy: testAccCheckServicePlanAccessDestroyed(servicePlanAccessGUID),
 			Steps: []resource.TestStep{
 				resource.TestStep{
 					Config: fmt.Sprintf(saResource,
 						defaultSysDomain(), user, password, defaultPcfDevOrgID()),
 					Check: resource.ComposeTestCheckFunc(
-						testAccCheckServiceAccessExists(ref,
+						testAccCheckServicePlanAccessExists(ref,
 							func(guid string) {
 								servicePlanAccessGUID = guid
 							}),
@@ -111,7 +111,7 @@ func TestAccServiceAccess_normal(t *testing.T) {
 		})
 }
 
-func TestAccServiceAccess_error(t *testing.T) {
+func TestAccServicePlanAccess_error(t *testing.T) {
 	user, password := getRedisBrokerCredentials()
 	deleteServiceBroker("p-redis")
 
@@ -121,7 +121,7 @@ func TestAccServiceAccess_error(t *testing.T) {
 		resource.TestCase{
 			PreCheck:     func() { testAccPreCheck(t) },
 			Providers:    testAccProviders,
-			CheckDestroy: testAccCheckServiceAccessDestroyed(servicePlanAccessGUID),
+			CheckDestroy: testAccCheckServicePlanAccessDestroyed(servicePlanAccessGUID),
 			Steps: []resource.TestStep{
 				resource.TestStep{
 					Config:      fmt.Sprintf(saResourceError, defaultSysDomain(), user, password, defaultPcfDevOrgID()),
@@ -131,7 +131,7 @@ func TestAccServiceAccess_error(t *testing.T) {
 		})
 }
 
-func testAccCheckServiceAccessExists(resource string,
+func testAccCheckServicePlanAccessExists(resource string,
 	setServicePlanAccessGUID func(string)) resource.TestCheckFunc {
 
 	return func(s *terraform.State) (err error) {
@@ -190,7 +190,7 @@ func testAccCheckServicePlan(resource string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckServiceAccessDestroyed(servicePlanAccessGUID string) resource.TestCheckFunc {
+func testAccCheckServicePlanAccessDestroyed(servicePlanAccessGUID string) resource.TestCheckFunc {
 
 	return func(s *terraform.State) error {
 

--- a/website/cf.erb
+++ b/website/cf.erb
@@ -88,7 +88,7 @@
 					<a href="/docs/providers/cf/r/service_broker.html">cf_service_broker</a>
 					</li>
 					<li<%= sidebar_current("docs-cf-resource-service-access") %>>
-					<a href="/docs/providers/cf/r/service_access.html">cf_service_access</a>
+					<a href="/docs/providers/cf/r/service_plan_access.html">cf_service_plan_access</a>
 					</li>
 					<li<%= sidebar_current("docs-cf-resource-service-instance") %>>
 					<a href="/docs/providers/cf/r/service_instance.html">cf_service_instance</a>

--- a/website/docs/r/service_access.html.markdown
+++ b/website/docs/r/service_access.html.markdown
@@ -8,15 +8,22 @@ description: |-
 
 # cf\_service\_access
 
-Provides a Cloud Foundry resource for managing [access](https://docs.cloudfoundry.org/services/access-control.html) to service plans published by Cloud Foundry [service brokers](https://docs.cloudfoundry.org/services/).
+Provides a Cloud Foundry resource for managing [access](https://docs.cloudfoundry.org/services/access-control.html)
+to service plans published by Cloud Foundry [service brokers](https://docs.cloudfoundry.org/services/).
 
 ## Example Usage
 
-The following example enables access to a specific plan of a given service broker within an Org.
+The first example enables access to a specific plan of a given service broker to all organizations.
+The second example gives access to a specific org.
 
 ```
 resource "cf_service_access" "org1-mysql-512mb" {
     plan = "${cf_service_broker.mysql.service_plans["p-mysql/512mb"]}"
+    public = true
+}
+
+resource "cf_service_access" "org1-mysql-512mb" {
+    plan = "${cf_service_broker.mysql.service_plans["p-mysql/1gb"]}"
     org = "${cf_org.org1.id}"
 }
 ```
@@ -26,11 +33,15 @@ resource "cf_service_access" "org1-mysql-512mb" {
 The following arguments are supported:
 
 * `plan` - (Required) The ID of the service plan to grant access to
-* `org` - (Required) The ID of the Org which should have access to the plan
+* `org` - (Optional) The ID of the Org which should have access to the plan. Conflicts with `public`.
+* `public` - (Optional) Boolean that controls the public state of the plan. Conflicts with `org`.
 
 ## Import
 
-The current Service Access can be imported using the `service_access`, e.g.
+The current Service Access can be imported using an `id`.
+
+If given `id` matches existing [`service_plan_visibilities`](https://apidocs.cloudfoundry.org/280/service_plan_visibilities/list_all_service_plan_visibilities.html),
+resource will be imported as a `service_access` targeting an organization. Otherwhise, it will be imported as `service_access` controling plan's public state. E.g.
 
 ```
 $ terraform import cf_service_access.org1-mysql-512mb a-guid

--- a/website/docs/r/service_access.html.markdown
+++ b/website/docs/r/service_access.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 The current Service Access can be imported using an `id`.
 
 If given `id` matches existing [`service_plan_visibilities`](https://apidocs.cloudfoundry.org/280/service_plan_visibilities/list_all_service_plan_visibilities.html),
-resource will be imported as a `service_access` targeting an organization. Otherwhise, it will be imported as `service_access` controling plan's public state. E.g.
+resource will be imported as a `service_access` targeting an organization. Otherwise, it will be imported as `service_access` controlling plan's public state. E.g.
 
 ```
 $ terraform import cf_service_access.org1-mysql-512mb a-guid

--- a/website/docs/r/service_plan_access.html.markdown
+++ b/website/docs/r/service_plan_access.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "cf"
-page_title: "Cloud Foundry: cf_service_access"
+page_title: "Cloud Foundry: cf_service_plan_access"
 sidebar_current: "docs-cf-resource-service-access"
 description: |-
   Provides a Cloud Foundry Service Access resource.
@@ -17,12 +17,12 @@ The first example enables access to a specific plan of a given service broker to
 The second example gives access to a specific org.
 
 ```
-resource "cf_service_access" "org1-mysql-512mb" {
+resource "cf_service_plan_access" "org1-mysql-512mb" {
     plan = "${cf_service_broker.mysql.service_plans["p-mysql/512mb"]}"
     public = true
 }
 
-resource "cf_service_access" "org1-mysql-512mb" {
+resource "cf_service_plan_access" "org1-mysql-512mb" {
     plan = "${cf_service_broker.mysql.service_plans["p-mysql/1gb"]}"
     org = "${cf_org.org1.id}"
 }
@@ -41,8 +41,15 @@ The following arguments are supported:
 The current Service Access can be imported using an `id`.
 
 If given `id` matches existing [`service_plan_visibilities`](https://apidocs.cloudfoundry.org/280/service_plan_visibilities/list_all_service_plan_visibilities.html),
-resource will be imported as a `service_access` targeting an organization. Otherwise, it will be imported as `service_access` controlling plan's public state. E.g.
+resource will be imported as a `service_plan_access` targeting an organization.
+
+If the given `id` matches [a service plan id](http://apidocs.cloudfoundry.org/280/service_plans/updating_a_service_plan.html),
+then the resource will be imported as `service_plan_access` controlling plan's public state.
+
+Otherwise, the import would fail.
+
+E.g.
 
 ```
-$ terraform import cf_service_access.org1-mysql-512mb a-guid
+$ terraform import cf_service_plan_access.org1-mysql-512mb a-guid
 ```


### PR DESCRIPTION
When creating a service-broker, service plans are private by default (ie: "public" : false attribute of /v2/service_plans, which make the service invisible in the marketplace).

The PR propose to add the optional `public` attribute to the cf_service_access resource. This attribute controls whenever the associated plan should be set public or private. It conflicts with `org` attribute that 
controls per-org access.

### Resource

```
resource "cf_service_access" "org1-mysql-512mb" {
     plan = "${cf_service_broker.mysql.service_plans["p-mysql/512mb"]}"
     public = true
}

resource "cf_service_access" "org1-mysql-512mb" {
    plan = "${cf_service_broker.mysql.service_plans["p-mysql/1gb"]}"
    org = "${cf_org.org1.id}"
}
```

Argument reference:
 * `plan` - (Required) The ID of the service plan to grant access to
 * `org` - (Optional) The ID of the Org which should have access to the plan. Conflicts with `public`.
 * `public` - (Optional) Boolean that controls the public state of the plan. Conflicts with `org`.

### Import

Import syntax is unchanged but its behavior is modified.
```
$ terraform import cf_service_access.org1-mysql-512mb a-guid
```
If given `id` matches existing [`service_plan_visibilities`](https://apidocs.cloudfoundry.org/280/service_plan_visibilities/list_all_service_plan_visibilities.html), resource will be imported as a `service_access` targeting an organization. Otherwise, it will be imported as `service_access` controlling plan's public state.

<!---
@huboard:{"order":26.004550195,"milestone_order":24.016805040840083,"custom_state":""}
-->
