### PR TITLE
Handle private domains in data cf_domain

### DIFF
--- a/cloudfoundry/data_source_cf_domain.go
+++ b/cloudfoundry/data_source_cf_domain.go
@@ -61,7 +61,7 @@ func dataSourceDomainRead(d *schema.ResourceData, meta interface{}) (err error) 
 	if privateDomains, err = dm.GetPrivateDomains(); err != nil {
 		return
 	}
-	domains = append(sharedDomains, privateDomains[:0]...)
+	domains = append(sharedDomains, privateDomains...)
 
 	if v, ok := d.GetOk("sub_domain"); ok {
 		prefix = v.(string) + "."

--- a/cloudfoundry/data_source_cf_domain_test.go
+++ b/cloudfoundry/data_source_cf_domain_test.go
@@ -1,9 +1,9 @@
 package cloudfoundry
 
 import (
-	"testing"
 	"fmt"
 	"github.com/hashicorp/terraform/helper/resource"
+	"testing"
 )
 
 const domainDataResource = `

--- a/cloudfoundry/data_source_cf_domain_test.go
+++ b/cloudfoundry/data_source_cf_domain_test.go
@@ -2,14 +2,30 @@ package cloudfoundry
 
 import (
 	"testing"
-
+	"fmt"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 const domainDataResource = `
-
 data "cf_domain" "tcp" {
     sub_domain = "tcp"
+}
+`
+
+const privateDomainDataResource = `
+resource "cf_org" "myorg" {
+	name = "myorg"
+}
+
+resource "cf_domain" "mydomain" {
+  sub_domain = "private"
+  domain     = "%[1]s"
+  org = "${cf_org.myorg.id}"
+}
+
+data "cf_domain" "private" {
+  domain = "${cf_domain.mydomain.domain}"
+  sub_domain = "private"
 }
 `
 
@@ -32,6 +48,25 @@ func TestAccDataSourceDomain_normal(t *testing.T) {
 							ref, "sub_domain", "tcp"),
 						resource.TestCheckResourceAttr(
 							ref, "domain", defaultAppDomain()),
+					),
+				},
+			},
+		})
+}
+
+func TestAccDataSourceDomain_private(t *testing.T) {
+	ref := "data.cf_domain.private"
+	resource.Test(t,
+		resource.TestCase{
+			PreCheck:  func() { testAccPreCheck(t) },
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				resource.TestStep{
+					Config: fmt.Sprintf(privateDomainDataResource, defaultAppDomain()),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(ref, "name", "private."+defaultAppDomain()),
+						resource.TestCheckResourceAttr(ref, "sub_domain", "private"),
+						resource.TestCheckResourceAttr(ref, "domain", defaultAppDomain()),
 					),
 				},
 			},


### PR DESCRIPTION
* resolves issue #18 
* adds test that checks that data `cf_domain` can find private domains

<!---
@huboard:{"order":26.005200260000002,"milestone_order":24.019206721344165,"custom_state":""}
-->
