### PR TITLE
Structured credentials in cf_user_provided_services

### DIFF
--- a/vendor/github.com/hashicorp/terraform/helper/structure/expand_json.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/expand_json.go
@@ -1,0 +1,11 @@
+package structure
+
+import "encoding/json"
+
+func ExpandJsonFromString(jsonString string) (map[string]interface{}, error) {
+	var result map[string]interface{}
+
+	err := json.Unmarshal([]byte(jsonString), &result)
+
+	return result, err
+}

--- a/vendor/github.com/hashicorp/terraform/helper/structure/flatten_json.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/flatten_json.go
@@ -1,0 +1,16 @@
+package structure
+
+import "encoding/json"
+
+func FlattenJsonToString(input map[string]interface{}) (string, error) {
+	if len(input) == 0 {
+		return "", nil
+	}
+
+	result, err := json.Marshal(input)
+	if err != nil {
+		return "", err
+	}
+
+	return string(result), nil
+}

--- a/vendor/github.com/hashicorp/terraform/helper/structure/normalize_json.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/normalize_json.go
@@ -1,0 +1,24 @@
+package structure
+
+import "encoding/json"
+
+// Takes a value containing JSON string and passes it through
+// the JSON parser to normalize it, returns either a parsing
+// error or normalized JSON string.
+func NormalizeJsonString(jsonString interface{}) (string, error) {
+	var j interface{}
+
+	if jsonString == nil || jsonString.(string) == "" {
+		return "", nil
+	}
+
+	s := jsonString.(string)
+
+	err := json.Unmarshal([]byte(s), &j)
+	if err != nil {
+		return s, err
+	}
+
+	bytes, _ := json.Marshal(j)
+	return string(bytes[:]), nil
+}

--- a/vendor/github.com/hashicorp/terraform/helper/structure/suppress_json_diff.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/suppress_json_diff.go
@@ -1,0 +1,21 @@
+package structure
+
+import (
+	"reflect"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func SuppressJsonDiff(k, old, new string, d *schema.ResourceData) bool {
+	oldMap, err := ExpandJsonFromString(old)
+	if err != nil {
+		return false
+	}
+
+	newMap, err := ExpandJsonFromString(new)
+	if err != nil {
+		return false
+	}
+
+	return reflect.DeepEqual(oldMap, newMap)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1101,6 +1101,12 @@
 			"revisionTime": "2018-01-09T23:13:33Z"
 		},
 		{
+			"checksumSHA1": "Fzbv+N7hFXOtrR6E7ZcHT3jEE9s=",
+			"path": "github.com/hashicorp/terraform/helper/structure",
+			"revision": "0e69f1542dcbd39c6e5b3327916fc7b70dcdc70b",
+			"revisionTime": "2018-01-11T18:50:06Z"
+		},
+		{
 			"checksumSHA1": "yFWmdS6yEJZpRJzUqd/mULqCYGk=",
 			"path": "github.com/hashicorp/terraform/moduledeps",
 			"revision": "a6008b8a48a749c7c167453b9cf55ffd572b9a5d",

--- a/website/docs/r/user_provided_service.html.markdown
+++ b/website/docs/r/user_provided_service.html.markdown
@@ -12,7 +12,7 @@ Provides a Cloud Foundry resource for managing Cloud Foundry [User Provided Serv
 
 ## Example Usage
 
-The following is a User Provided Service created within the referenced space. 
+The following are User Provided Service created within the referenced space.
 
 ```
 resource "cf_user_provided_service" "mq" {
@@ -21,8 +21,26 @@ resource "cf_user_provided_service" "mq" {
   credentials = {
     "url" = "mq://localhost:9000"
     "username" = "admin"
-    "password" = "admin"    
+    "password" = "admin"
   }
+}
+
+resource "cf_user_provided_service" "mail" {
+  name = "mail-server"
+  space = "${cf_space.dev.id}"
+  credentials_json = <<JSON
+  {
+    "server" : {
+      "host" : "smtp.example.com",
+      "port" : 25,
+      "tls"  : false
+    },
+    "auth" : {
+      "user"     : "login",
+      "password" : "secret"
+    }
+  }
+  JSON
 }
 ```
 
@@ -31,8 +49,9 @@ resource "cf_user_provided_service" "mq" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the Service Instance in Cloud Foundry
-* `space` - (Required) The ID of the [space](/docs/providers/cloudfoundry/r/space.html) 
-* `credentials` - (Optional) Arbitrary credentials in the form of key-value pairs and delivered to applications via [VCAP_SERVICES Env variables](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES)
+* `space` - (Required) The ID of the [space](/docs/providers/cloudfoundry/r/space.html)
+* `credentials` - (Optional) Arbitrary credentials in the form of key-value pairs and delivered to applications via [VCAP_SERVICES Env variables](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES). Conflicts with `credentials_json`.
+* `credentials_json` - (Optional) Same as `credentials` but in the form of a stringified JSON object. Conflicts with `credentials`.
 * `syslog_drain_url` - (Optional) URL to which logs for bound applications will be streamed
 * `route_service_url` - (Optional) URL to which requests for bound routes will be forwarded. Scheme for this URL must be https
 


### PR DESCRIPTION
This PR  allows creation of credentials that are not limited to key-value pairs by adding `credentials_json` attribute to `cf_user_provided_service` resource. 

`credentials_json` expects a JSON-encoded string and conflicts with the previous `credentials` attributes.

Example: 
```
resource "cf_user_provided_service" "mail" {
  name = "mail-server"
  space = "${cf_space.dev.id}"
  credentials_json = <<JSON
  {
    "server" : {
      "host" : "smtp.example.com",
      "port" : 25,
      "tls"  : false
    },
    "auth" : {
      "user"     : "login",
      "password" : "secret"
    }
  }
  JSON
}
```

<!---
@huboard:{"order":26.007800780026002,"milestone_order":24.01560432066006,"custom_state":""}
-->
