### PR TITLE
Allow sharing private domains among organizations

### DIFF
--- a/cloudfoundry/cfapi/domain_manager.go
+++ b/cloudfoundry/cfapi/domain_manager.go
@@ -176,6 +176,36 @@ func (dm *DomainManager) GetPrivateDomain(guid string) (domain CCDomain, err err
 	return
 }
 
+// HasPrivateDomainAccess -
+func (dm *DomainManager) HasPrivateDomainAccess(org, domain string) (bool, error) {
+	domainList := CCDomainList{}
+	path := fmt.Sprintf("%s/v2/organizations/%s/private_domains", dm.apiEndpoint, org)
+	if err := dm.ccGateway.GetResource(path, &domainList); err != nil {
+		return false, err
+	}
+	for _, d := range domainList.Resources {
+		if d.Metadata.GUID == domain {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// CreatePrivateDomainAccess -
+func (dm *DomainManager) CreatePrivateDomainAccess(org, domain string) (err error) {
+	resource := CCOrgResource{}
+	path := fmt.Sprintf("/v2/organizations/%s/private_domains/%s", org, domain)
+	err = dm.ccGateway.UpdateResource(dm.apiEndpoint, path, nil, &resource)
+	return
+}
+
+// DeletePrivateDomainAccess -
+func (dm *DomainManager) DeletePrivateDomainAccess(org, domain string) (err error) {
+	path := fmt.Sprintf("/v2/organizations/%s/private_domains/%s", org, domain)
+	err = dm.ccGateway.DeleteResource(dm.apiEndpoint, path)
+	return
+}
+
 // DeletePrivateDomain -
 func (dm *DomainManager) DeletePrivateDomain(guid string) (err error) {
 	err = dm.ccGateway.DeleteResource(dm.apiEndpoint, fmt.Sprintf("/v2/private_domains/%s", guid))

--- a/cloudfoundry/import_cf_private_domain_access_test.go
+++ b/cloudfoundry/import_cf_private_domain_access_test.go
@@ -1,9 +1,9 @@
 package cloudfoundry
 
 import (
-	"testing"
 	"fmt"
 	"github.com/hashicorp/terraform/helper/resource"
+	"testing"
 )
 
 func TestAccPrivateDomainAccess_importBasic(t *testing.T) {
@@ -19,16 +19,16 @@ func TestAccPrivateDomainAccess_importBasic(t *testing.T) {
 
 	resource.Test(t,
 		resource.TestCase{
-			PreCheck:     func() { testAccPreCheck(t) },
-			Providers:    testAccProviders,
+			PreCheck:  func() { testAccPreCheck(t) },
+			Providers: testAccProviders,
 			Steps: []resource.TestStep{
 				resource.TestStep{
 					Config: fmt.Sprintf(privateDomainAccessResourceCreate, defaultAppDomain()),
 				},
 				resource.TestStep{
-					ResourceName:            resourceName,
-					ImportState:             true,
-					ImportStateVerify:       true,
+					ResourceName:      resourceName,
+					ImportState:       true,
+					ImportStateVerify: true,
 				},
 			},
 		})

--- a/cloudfoundry/import_cf_private_domain_access_test.go
+++ b/cloudfoundry/import_cf_private_domain_access_test.go
@@ -1,0 +1,35 @@
+package cloudfoundry
+
+import (
+	"testing"
+	"fmt"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccPrivateDomainAccess_importBasic(t *testing.T) {
+	resourceName := "cf_private_domain_access.access-to-org"
+
+	// toIgnore := []string{"staging_asgs.#"}
+	// session := testSession()
+	// asm := session.ASGManager()
+	// secGroup, err := asm.Read("public_networks")
+	// if err == nil && secGroup.GUID != "" {
+	// 	toIgnore = append(toIgnore, fmt.Sprintf("staging_asgs.%d", resourceStringHash(secGroup.GUID)))
+	// }
+
+	resource.Test(t,
+		resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			Steps: []resource.TestStep{
+				resource.TestStep{
+					Config: fmt.Sprintf(privateDomainAccessResourceCreate, defaultAppDomain()),
+				},
+				resource.TestStep{
+					ResourceName:            resourceName,
+					ImportState:             true,
+					ImportStateVerify:       true,
+				},
+			},
+		})
+}

--- a/cloudfoundry/provider.go
+++ b/cloudfoundry/provider.go
@@ -64,6 +64,7 @@ func Provider() terraform.ResourceProvider {
 			"cf_config":                resourceConfig(),
 			"cf_user":                  resourceUser(),
 			"cf_domain":                resourceDomain(),
+			"cf_private_domain_access": resourcePrivateDomainAccess(),
 			"cf_quota":                 resourceQuota(),
 			"cf_asg":                   resourceAsg(),
 			"cf_default_asg":           resourceDefaultAsg(),

--- a/cloudfoundry/resource_cf_private_domain_access.go
+++ b/cloudfoundry/resource_cf_private_domain_access.go
@@ -117,6 +117,8 @@ func resourcePrivateDomainAccessRead(d *schema.ResourceData, meta interface{}) (
 		return err
 	}
 
+	d.Set("org", org)
+	d.Set("domain", domain)
 	return
 }
 

--- a/cloudfoundry/resource_cf_private_domain_access.go
+++ b/cloudfoundry/resource_cf_private_domain_access.go
@@ -88,7 +88,7 @@ func resourcePrivateDomainAccessCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	domain := d.Get("domain").(string)
-	org    := d.Get("org").(string)
+	org := d.Get("org").(string)
 
 	dm := session.DomainManager()
 	if err = dm.CreatePrivateDomainAccess(org, domain); err != nil {

--- a/cloudfoundry/resource_cf_private_domain_access.go
+++ b/cloudfoundry/resource_cf_private_domain_access.go
@@ -28,10 +28,6 @@ func resourcePrivateDomainAccess() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"linked": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 		},
 	}
 }

--- a/cloudfoundry/resource_cf_private_domain_access.go
+++ b/cloudfoundry/resource_cf_private_domain_access.go
@@ -1,0 +1,142 @@
+package cloudfoundry
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+)
+
+func resourcePrivateDomainAccess() *schema.Resource {
+	return &schema.Resource{
+		Create: resourcePrivateDomainAccessCreate,
+		Read:   resourcePrivateDomainAccessRead,
+		Delete: resourcePrivateDomainAccessDelete,
+		Importer: &schema.ResourceImporter{
+			State: ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"domain": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"org": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"linked": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func computeID(org, domain string) string {
+	return fmt.Sprintf("%s/%s", org, domain)
+}
+
+func parseID(ID string) (org string, domain string, err error) {
+	parts := strings.Split(ID, "/")
+	if len(parts) != 2 {
+		err = fmt.Errorf("unable to parse ID '%s', expected format is '<org-guid>/<domain-guid>'", ID)
+	} else {
+		org = parts[0]
+		domain = parts[1]
+	}
+	return
+}
+
+// PrivateDomainAccessImport -
+// Checks that user-given ID matches <guid>/<guid> format
+func PrivateDomainAccessImport(d *schema.ResourceData, meta interface{}) (res []*schema.ResourceData, err error) {
+	// session := meta.(*cfapi.Session)
+	// if session == nil {
+	// 	err = fmt.Errorf("client is nil")
+	// 	return
+	// }
+	// dm := session.DomainManager()
+	id := d.Id()
+
+	// var org, domain string
+	// if org, domain, err = parseID(id); err != nil {
+	if _, _, err = parseID(id); err != nil {
+		return
+	}
+
+	// var found bool
+	// found, err = dm.HasPrivateDomainAccess(org, domain)
+	// if err != nil {
+	// 	return
+	// }
+
+	// if !found {
+	// 	err = fmt.Errorf("organization '%s' has no access to private domain '%s'", org, domain)
+	// 	return
+	// }
+	return schema.ImportStatePassthrough(d, meta)
+}
+
+func resourcePrivateDomainAccessCreate(d *schema.ResourceData, meta interface{}) (err error) {
+	session := meta.(*cfapi.Session)
+	if session == nil {
+		return fmt.Errorf("client is nil")
+	}
+
+	domain := d.Get("domain").(string)
+	org    := d.Get("org").(string)
+
+	dm := session.DomainManager()
+	if err = dm.CreatePrivateDomainAccess(org, domain); err != nil {
+		return
+	}
+
+	d.SetId(computeID(org, domain))
+	return nil
+}
+
+func resourcePrivateDomainAccessRead(d *schema.ResourceData, meta interface{}) (err error) {
+	session := meta.(*cfapi.Session)
+	if session == nil {
+		return fmt.Errorf("client is nil")
+	}
+
+	id := d.Id()
+	// id in read hook comes from create or import callback which ensure id's validity
+	var org, domain string
+	org, domain, _ = parseID(id)
+
+	dm := session.DomainManager()
+	var found bool
+	if found, err = dm.HasPrivateDomainAccess(org, domain); err != nil || !found {
+		d.SetId("")
+		return err
+	}
+
+	return
+}
+
+func resourcePrivateDomainAccessDelete(d *schema.ResourceData, meta interface{}) (err error) {
+	session := meta.(*cfapi.Session)
+	if session == nil {
+		return fmt.Errorf("client is nil")
+	}
+
+	dm := session.DomainManager()
+	id := d.Id()
+
+	// id in read hook comes from create or import callback which ensure id's validity
+	var org, domain string
+	org, domain, _ = parseID(id)
+
+	err = dm.DeletePrivateDomainAccess(org, domain)
+	return
+}
+
+// Local Variables:
+// ispell-local-dictionary: "american"
+// End:

--- a/cloudfoundry/resource_cf_private_domain_access_test.go
+++ b/cloudfoundry/resource_cf_private_domain_access_test.go
@@ -1,0 +1,167 @@
+package cloudfoundry
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+)
+
+const privateDomainAccessResourceCreate = `
+resource "cf_org" "org1" {
+  name = "org1"
+}
+
+resource "cf_org" "org2" {
+  name = "org2"
+}
+
+resource "cf_org" "org3" {
+  name = "org3"
+}
+
+resource "cf_domain" "private" {
+    sub_domain = "private"
+    domain     = "%s"
+    org        = "${cf_org.org1.id}"
+}
+
+resource "cf_private_domain_access" "access-to-org" {
+    domain     = "${cf_domain.private.id}"
+    org        = "${cf_org.org2.id}"
+}
+`
+
+const privateDomainAccessResourceUpdate = `
+resource "cf_org" "org1" {
+  name = "org1"
+}
+
+resource "cf_org" "org2" {
+  name = "org2"
+}
+
+resource "cf_org" "org3" {
+  name = "org3"
+}
+
+resource "cf_domain" "private" {
+    sub_domain = "private"
+    domain     = "%s"
+    org        = "${cf_org.org1.id}"
+}
+
+resource "cf_private_domain_access" "access-to-org" {
+    domain     = "${cf_domain.private.id}"
+    org        = "${cf_org.org3.id}"
+}
+`
+
+
+const privateDomainAccessResourceDelete = `
+resource "cf_org" "org1" {
+  name = "org1"
+}
+
+resource "cf_org" "org2" {
+  name = "org2"
+}
+
+resource "cf_org" "org3" {
+  name = "org3"
+}
+
+resource "cf_domain" "private" {
+    sub_domain = "private"
+    domain     = "%s"
+    org        = "${cf_org.org1.id}"
+}
+`
+
+func TestAccPrivateDomainAccess_normal(t *testing.T) {
+	ref := "cf_private_domain_access.access-to-org"
+
+	resource.Test(t,
+		resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			Steps: []resource.TestStep{
+				resource.TestStep{
+					Config: fmt.Sprintf(privateDomainAccessResourceCreate, defaultAppDomain()),
+					Check: resource.ComposeTestCheckFunc(
+						checkPrivateDomainShare(ref, "cf_domain.private", "cf_org.org2", true),
+						checkPrivateDomainShare(ref, "cf_domain.private", "cf_org.org3", false),
+					),
+				},
+				resource.TestStep{
+					Config: fmt.Sprintf(privateDomainAccessResourceUpdate, defaultAppDomain()),
+					Check: resource.ComposeTestCheckFunc(
+						checkPrivateDomainShare(ref, "cf_domain.private", "cf_org.org2", false),
+						checkPrivateDomainShare(ref, "cf_domain.private", "cf_org.org3", true),
+					),
+				},
+				resource.TestStep{
+					Config: fmt.Sprintf(privateDomainAccessResourceDelete, defaultAppDomain()),
+					Check: resource.ComposeTestCheckFunc(
+						checkPrivateDomainShare("", "cf_domain.private", "cf_org.org2", false),
+						checkPrivateDomainShare("", "cf_domain.private", "cf_org.org3", false),
+					),
+				},
+			},
+		})
+}
+
+func checkPrivateDomainShare(resource, domain, org string, exists bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		session := testAccProvider.Meta().(*cfapi.Session)
+
+		drs, ok := s.RootModule().Resources[domain]
+		if !ok {
+			return fmt.Errorf("domain '%s' not found in terraform state", domain)
+		}
+
+		ors, ok := s.RootModule().Resources[org]
+		if !ok {
+			return fmt.Errorf("org '%s' not found in terraform state", org)
+		}
+
+		orgID    := ors.Primary.ID
+		domainID := drs.Primary.ID
+
+		dm := session.DomainManager()
+		found, err := dm.HasPrivateDomainAccess(orgID, domainID)
+		if err != nil {
+			return err
+		}
+
+		if !found && exists {
+			return fmt.Errorf("unable to find private domain access '%s(%s)' to org '%s(%s)'", domain, domainID, org, orgID)
+		}
+
+		if found && !exists {
+			return fmt.Errorf("private domain access '%s(%s)' to org '%s(%s)' not deleted as it ought to be", domain, domainID, org, orgID)
+		}
+
+		if len(resource) > 0 {
+			rs, ok := s.RootModule().Resources[resource]
+			if !ok {
+				return fmt.Errorf("private_domain_access '%s' not found in terraform state", resource)
+			}
+			session.Log.DebugMessage("terraform state for resource '%s': %# v", resource, rs)
+
+			id := rs.Primary.ID
+
+			if exists && id != fmt.Sprintf("%s/%s", orgID, domainID) {
+				return fmt.Errorf("unexpected private_domain_access resource identifier '%s' mismatch with '%s/%s'", id, orgID, domainID)
+			}
+		}
+
+		return nil
+	}
+}
+
+// Local Variables:
+// ispell-local-dictionary: "american"
+// End:

--- a/cloudfoundry/resource_cf_private_domain_access_test.go
+++ b/cloudfoundry/resource_cf_private_domain_access_test.go
@@ -59,7 +59,6 @@ resource "cf_private_domain_access" "access-to-org" {
 }
 `
 
-
 const privateDomainAccessResourceDelete = `
 resource "cf_org" "org1" {
   name = "org1"
@@ -85,8 +84,8 @@ func TestAccPrivateDomainAccess_normal(t *testing.T) {
 
 	resource.Test(t,
 		resource.TestCase{
-			PreCheck:     func() { testAccPreCheck(t) },
-			Providers:    testAccProviders,
+			PreCheck:  func() { testAccPreCheck(t) },
+			Providers: testAccProviders,
 			Steps: []resource.TestStep{
 				resource.TestStep{
 					Config: fmt.Sprintf(privateDomainAccessResourceCreate, defaultAppDomain()),
@@ -127,7 +126,7 @@ func checkPrivateDomainShare(resource, domain, org string, exists bool) resource
 			return fmt.Errorf("org '%s' not found in terraform state", org)
 		}
 
-		orgID    := ors.Primary.ID
+		orgID := ors.Primary.ID
 		domainID := drs.Primary.ID
 
 		dm := session.DomainManager()

--- a/website/docs/r/private_domain_access.html.markdown
+++ b/website/docs/r/private_domain_access.html.markdown
@@ -1,0 +1,40 @@
+---
+layout: "cf"
+page_title: "Cloud Foundry: cf_private_domain_access"
+sidebar_current: "docs-cf-resource-private-domain-access"
+description: |-
+  Provides a Cloud Foundry private domain acceess resource.
+---
+
+# cf\_private\_domain\_access
+
+Provides a resource for managing CLoud Foundry [organization](https://docs.cloudfoundry.org/concepts/roles.html)
+access to [private domains](https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#domains).
+
+## Example Usage
+
+The following is an example of giving an organization access to a private [domain]. The
+domain is retrieved via a [domain data source](/docs/providers/cloudfoundry/d/domain.html)
+and the organization via a [org data source)(/docs/providers/cloudfoundry/d/org.html).
+
+```
+resource "cf_private_domain_access" "shared-to-my-org" {
+  domain = "${data.cf_domain.domain.id}"
+  org    = "${data.cf_org.my-org.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain` - (Required, String) The GUID of private domain.
+* `org`    - (Required, String) The GUID of the organization.
+
+## Import
+
+The `cf_private_domain_access` can be imported using `<org-guid>/<domain-guid>' identifier, e.g.
+
+```
+$ terraform import cf_private_domain_access.my-access 84f5ba83-1728-481f-9a62-72d109e4be74/c8eba5e6-5a21-45ee-ae0a-59b1f650888a
+```


### PR DESCRIPTION
This PR implements a new `cf_private_domain_access` resource that allows to give additional organization access to a private domain as requested in issue #5.

### Example

```
data "cf_org" "org1" {
  name = "org1"
}

data "cf_org" "org2" {
  name = "org2"
}

data "cf_org" "org3" {
  name = "org3"
}

resource "cf_domain" "my-shared-domain" {
  name = "pcfdev-org.io"
  # org declared in cf_domain is the owning org of the private domain
  org = "${data.org1.id}" 
}

resource "cf_private_domain_access" "shared-to-org2" {
  domain = "${cf_domain.my-shared-domain.id}"
  org = "${data.org2.id}"
}

resource "cf_private_domain_access" "shared-to-org3" {
  domain = "${cf_domain.my-shared-domain.id}"
  org = "${data.org3.id}"
}
```

### Reference

```
The following arguments are supported:

* `domain` - (Required, String) The GUID of private domain.
* `org`    - (Required, String) The GUID of the organization.
```


### Import

The `cf_private_domain_access` can be imported using `\<org-guid\>/\<domain-guid\>' identifier, e.g.

```
$ terraform import cf_private_domain_access.my-access 84f5ba83-1728-481f-9a62-72d109e4be74/c8eba5e6-5a21-45ee-ae0a-59b1f650888a
```

### Progress

* [x] initial implementation
* [x] documentation
* [x] initial acceptance tests
* [x] import acceptance tests
* [x] additional testing in production use-cases

<!---
@huboard:{"order":26.0,"milestone_order":24.01080192016801,"custom_state":""}
-->
