### PR TITLE
Fix service instance binding

### DIFF
--- a/cloudfoundry/cfapi/service_manager.go
+++ b/cloudfoundry/cfapi/service_manager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	"code.cloudfoundry.org/cli/cf/api"
 	"code.cloudfoundry.org/cli/cf/api/resources"
@@ -13,6 +14,7 @@ import (
 	"code.cloudfoundry.org/cli/cf/errors"
 	"code.cloudfoundry.org/cli/cf/models"
 	"code.cloudfoundry.org/cli/cf/net"
+	"code.cloudfoundry.org/cli/cf/terminal"
 )
 
 // ServiceManager -
@@ -100,10 +102,11 @@ type CCServiceBrokerResource struct {
 
 // CCServiceInstance -
 type CCServiceInstance struct {
-	Name            string   `json:"name"`
-	SpaceGUID       string   `json:"space_guid"`
-	ServicePlanGUID string   `json:"service_plan_guid"`
-	Tags            []string `json:"tags,omitempty"`
+	Name            string                 `json:"name"`
+	SpaceGUID       string                 `json:"space_guid"`
+	ServicePlanGUID string                 `json:"service_plan_guid"`
+	Tags            []string               `json:"tags,omitempty"`
+	LastOperation   map[string]interface{} `json:"last_operation"`
 }
 
 // CCServiceInstanceResource -
@@ -469,6 +472,50 @@ func (sm *ServiceManager) ReadServiceInstance(serviceInstanceID string) (service
 	}
 
 	serviceInstance = resource.Entity
+	return
+}
+
+// WaitServiceInstanceToStart -
+func (sm *ServiceManager) WaitServiceInstanceToStart(serviceInstanceID string, timeout time.Duration) (err error) {
+	sm.log.UI.Say("Waiting for service instance %s to finish starting ..", terminal.EntityNameColor(serviceInstanceID))
+
+	c := make(chan error)
+	go func() {
+
+		var err error
+		var serviceInstance CCServiceInstance
+
+		for {
+			if serviceInstance, err = sm.ReadServiceInstance(serviceInstanceID); err != nil {
+				c <- err
+				return
+			}
+
+			if serviceInstance.LastOperation["type"] == "create" {
+				state := serviceInstance.LastOperation["state"]
+
+				switch state {
+				case "succeeded":
+					c <- nil
+					return
+				case "failed":
+					c <- fmt.Errorf("service instance %s crashed", serviceInstanceID)
+					return
+				}
+			}
+			time.Sleep(appStatePingSleep)
+		}
+	}()
+
+	select {
+	case err = <-c:
+		if err != nil {
+			return
+		}
+		sm.log.UI.Say("%s finished starting ...", terminal.EntityNameColor(serviceInstanceID))
+	case <-time.After(timeout):
+		err = fmt.Errorf("Service instance %s failed to start after %d seconds", serviceInstanceID, timeout/time.Second)
+	}
 	return
 }
 

--- a/cloudfoundry/cfapi/service_manager.go
+++ b/cloudfoundry/cfapi/service_manager.go
@@ -475,6 +475,50 @@ func (sm *ServiceManager) ReadServiceInstance(serviceInstanceID string) (service
 	return
 }
 
+// WaitServiceInstanceToDelete -
+func (sm *ServiceManager) WaitServiceInstanceToDelete(serviceInstanceID string, timeout time.Duration) (err error) {
+	sm.log.UI.Say("Waiting for service instance %s to finish deletion ..", terminal.EntityNameColor(serviceInstanceID))
+
+	c := make(chan error)
+	go func() {
+
+		var err error
+		var serviceInstance CCServiceInstance
+
+		for {
+			if serviceInstance, err = sm.ReadServiceInstance(serviceInstanceID); err != nil {
+				c <- err
+				return
+			}
+
+			if serviceInstance.LastOperation["type"] == "delete" {
+				state := serviceInstance.LastOperation["state"]
+
+				switch state {
+				case "succeeded":
+					c <- nil
+					return
+				case "failed":
+					c <- fmt.Errorf("service instance %s crashed", serviceInstanceID)
+					return
+				}
+			}
+			time.Sleep(appStatePingSleep)
+		}
+	}()
+
+	select {
+	case err = <-c:
+		if err != nil {
+			return
+		}
+		sm.log.UI.Say("%s finished deletion ...", terminal.EntityNameColor(serviceInstanceID))
+	case <-time.After(timeout):
+		err = fmt.Errorf("Service instance %s failed to delete after %d seconds", serviceInstanceID, timeout/time.Second)
+	}
+	return
+}
+
 // WaitServiceInstanceToStart -
 func (sm *ServiceManager) WaitServiceInstanceToStart(serviceInstanceID string, timeout time.Duration) (err error) {
 	sm.log.UI.Say("Waiting for service instance %s to finish starting ..", terminal.EntityNameColor(serviceInstanceID))

--- a/cloudfoundry/resource_cf_app.go
+++ b/cloudfoundry/resource_cf_app.go
@@ -431,7 +431,7 @@ func resourceAppCreate(d *schema.ResourceData, meta interface{}) (err error) {
 
 	// Bind services
 	if v, hasServiceBindings = d.GetOk("service_binding"); hasServiceBindings {
-		if serviceBindings, err = addServiceBindings(app.ID, getListOfStructs(v), am, session.Log, session); err != nil {
+		if serviceBindings, err = addServiceBindings(app.ID, getListOfStructs(v), am, session.Log); err != nil {
 			return
 		}
 	}
@@ -559,7 +559,7 @@ func resourceAppUpdate(d *schema.ResourceData, meta interface{}) (err error) {
 		}
 
 		var added []map[string]interface{}
-		if added, err = addServiceBindings(app.ID, bindingsToAdd, am, session.Log, session); err != nil {
+		if added, err = addServiceBindings(app.ID, bindingsToAdd, am, session.Log); err != nil {
 			return
 		}
 		if len(added) > 0 {
@@ -872,9 +872,7 @@ func updateMapping(old map[string]interface{}, new map[string]interface{},
 }
 
 func addServiceBindings(id string, add []map[string]interface{},
-	am *cfapi.AppManager, log *cfapi.Logger, session *cfapi.Session) (bindings []map[string]interface{}, err error) {
-
-	sm := session.ServiceManager()
+	am *cfapi.AppManager, log *cfapi.Logger) (bindings []map[string]interface{}, err error) {
 
 	var (
 		serviceInstanceID, bindingID string
@@ -891,11 +889,6 @@ func addServiceBindings(id string, add []map[string]interface{},
 		if v, ok := b["params"]; ok {
 			vv := v.(map[string]interface{})
 			params = &vv
-		}
-
-		// Check whetever service_instance exists and is in state 'succeeded'
-		if err = sm.WaitServiceInstanceToStart(serviceInstanceID, 600); err != nil {
-			return
 		}
 
 		if bindingID, bindingCredentials, err = am.CreateServiceBinding(id, serviceInstanceID, params); err != nil {

--- a/cloudfoundry/resource_cf_app.go
+++ b/cloudfoundry/resource_cf_app.go
@@ -431,7 +431,7 @@ func resourceAppCreate(d *schema.ResourceData, meta interface{}) (err error) {
 
 	// Bind services
 	if v, hasServiceBindings = d.GetOk("service_binding"); hasServiceBindings {
-		if serviceBindings, err = addServiceBindings(app.ID, getListOfStructs(v), am, session.Log); err != nil {
+		if serviceBindings, err = addServiceBindings(app.ID, getListOfStructs(v), am, session.Log, session); err != nil {
 			return
 		}
 	}
@@ -559,7 +559,7 @@ func resourceAppUpdate(d *schema.ResourceData, meta interface{}) (err error) {
 		}
 
 		var added []map[string]interface{}
-		if added, err = addServiceBindings(app.ID, bindingsToAdd, am, session.Log); err != nil {
+		if added, err = addServiceBindings(app.ID, bindingsToAdd, am, session.Log, session); err != nil {
 			return
 		}
 		if len(added) > 0 {
@@ -872,7 +872,9 @@ func updateMapping(old map[string]interface{}, new map[string]interface{},
 }
 
 func addServiceBindings(id string, add []map[string]interface{},
-	am *cfapi.AppManager, log *cfapi.Logger) (bindings []map[string]interface{}, err error) {
+	am *cfapi.AppManager, log *cfapi.Logger, session *cfapi.Session) (bindings []map[string]interface{}, err error) {
+
+	sm := session.ServiceManager()
 
 	var (
 		serviceInstanceID, bindingID string
@@ -890,6 +892,12 @@ func addServiceBindings(id string, add []map[string]interface{},
 			vv := v.(map[string]interface{})
 			params = &vv
 		}
+
+		// Check whetever service_instance exists and is in state 'succeeded'
+		if err = sm.WaitServiceInstanceToStart(serviceInstanceID, 600); err != nil {
+			return
+		}
+
 		if bindingID, bindingCredentials, err = am.CreateServiceBinding(id, serviceInstanceID, params); err != nil {
 			return
 		}

--- a/cloudfoundry/resource_cf_service_instance.go
+++ b/cloudfoundry/resource_cf_service_instance.go
@@ -195,12 +195,6 @@ func resourceServiceInstanceDelete(d *schema.ResourceData, meta interface{}) (er
 		return
 	}
 
-	// Check whetever service_instance is deleted and is in state 'succeeded'
-	timeout := time.Second * time.Duration(d.Get("timeout").(int))
-	if err = sm.WaitServiceInstanceToDelete(d.Id(), timeout); err != nil {
-		return
-	}
-
 	session.Log.DebugMessage("Deleted Service Instance : %s", d.Id())
 
 	return


### PR DESCRIPTION
- Solution to Issue [#40](https://github.com/mevansam/terraform-provider-cf/issues/40)
- Please consider to add to `cf_service_instance` resources the attribute `timeout`, which defines the timeout time for an application to start. The default value is 60 seconds.