### PR TITLE
Rework cf_app local download to use ioutil.Temp & clean up temp files

### DIFF
--- a/cloudfoundry/provider.go
+++ b/cloudfoundry/provider.go
@@ -88,10 +88,6 @@ func Provider() terraform.ResourceProvider {
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 
-	if err := initRepoManager(); err != nil {
-		return nil, err
-	}
-
 	config := Config{
 		endpoint:          d.Get("api_url").(string),
 		User:              d.Get("user").(string),

--- a/cloudfoundry/provider_test.go
+++ b/cloudfoundry/provider_test.go
@@ -30,10 +30,6 @@ var pcfDevSpaceID string
 
 func init() {
 
-	if err := initRepoManager(); err != nil {
-		panic(err)
-	}
-
 	testAccProvider = Provider().(*schema.Provider)
 	testAccProviders = map[string]terraform.ResourceProvider{
 		"cloudfoundry": testAccProvider,
@@ -377,7 +373,7 @@ func assertMapEquals(key string, attributes map[string]string, actual map[string
 
 			l := len(keyParts)
 			m := expected
-			for _, kk := range keyParts[1 : l-1] {
+			for _, kk := range keyParts[1: l-1] {
 				if _, ok := m[kk]; !ok {
 					m[kk] = make(map[string]interface{})
 				}

--- a/cloudfoundry/provider_test.go
+++ b/cloudfoundry/provider_test.go
@@ -373,7 +373,7 @@ func assertMapEquals(key string, attributes map[string]string, actual map[string
 
 			l := len(keyParts)
 			m := expected
-			for _, kk := range keyParts[1: l-1] {
+			for _, kk := range keyParts[1 : l-1] {
 				if _, ok := m[kk]; !ok {
 					m[kk] = make(map[string]interface{})
 				}

--- a/cloudfoundry/repo/git_repository.go
+++ b/cloudfoundry/repo/git_repository.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"sync"
 
-	git "gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"os"
 )
 
 const (
@@ -79,4 +80,9 @@ func (r *GitRepository) String() string {
 		panic(err.Error())
 	}
 	return ref.Hash().String()
+}
+
+// Clean -
+func (r *GitRepository) Clean() error {
+	return os.RemoveAll(r.repoPath)
 }

--- a/cloudfoundry/repo/git_repository_test.go
+++ b/cloudfoundry/repo/git_repository_test.go
@@ -107,7 +107,7 @@ func testTaggedContent(t *testing.T) {
 
 func getGitRepo(t *testing.T) (gitRepo repo.Repository) {
 
-	repoManager := repo.NewManager()
+	repoManager := repo.NewRepoManager()
 	gitRepo, err := repoManager.GetGitRepository("https://github.com/mevansam/test-app.git", nil, nil, nil)
 	checkError(t, err)
 

--- a/cloudfoundry/repo/git_repository_test.go
+++ b/cloudfoundry/repo/git_repository_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/repo"
 
-	git "gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 )
 
@@ -109,7 +109,7 @@ func testTaggedContent(workspace string, t *testing.T) {
 
 func getGitRepo(workspace string, t *testing.T) (gitRepo repo.Repository) {
 
-	repoManager := repo.NewManager(workspace)
+	repoManager := repo.NewManager()
 	gitRepo, err := repoManager.GetGitRepository("https://github.com/mevansam/test-app.git", nil, nil, nil)
 	checkError(t, err)
 

--- a/cloudfoundry/repo/git_repository_test.go
+++ b/cloudfoundry/repo/git_repository_test.go
@@ -108,7 +108,7 @@ func testTaggedContent(t *testing.T) {
 func getGitRepo(t *testing.T) (gitRepo repo.Repository) {
 
 	repoManager := repo.NewRepoManager()
-	gitRepo, err := repoManager.GetGitRepository("https://github.com/mevansam/test-app.git", nil, nil, nil)
+	gitRepo, err := repoManager.GetGitRepository("", "https://github.com/mevansam/test-app.git", nil, nil, nil)
 	checkError(t, err)
 
 	path := gitRepo.GetPath()

--- a/cloudfoundry/repo/github_release.go
+++ b/cloudfoundry/repo/github_release.go
@@ -210,3 +210,8 @@ func (r *GithubRelease) createArchive(in io.ReadCloser) (err error) {
 	}
 	return err
 }
+
+// Clean -
+func (r *GithubRelease) Clean() error {
+	return os.Remove(r.archivePath)
+}

--- a/cloudfoundry/repo/github_release_test.go
+++ b/cloudfoundry/repo/github_release_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/repo"
+	"os"
 )
 
 func TestGithubReleaseRepo(t *testing.T) {
@@ -21,7 +22,7 @@ func TestGithubReleaseRepo(t *testing.T) {
 func testReleaseFileDownload(t *testing.T) {
 	fmt.Println("Test: release file download")
 
-	repoManager := repo.NewManager(workspace)
+	repoManager := repo.NewRepoManager()
 	testUser := os.Getenv("GITHUB_USER")
 	testPassword := os.Getenv("GITHUB_TOKEN")
 	ghRelease, err := repoManager.GetGithubRelease("mevansam", "test-app", "test_release_file.zip", &testUser, &testPassword)
@@ -48,7 +49,7 @@ func testReleaseFileDownload(t *testing.T) {
 func testSourceZipFileDownload(t *testing.T) {
 	fmt.Println("Test: source zip file download")
 
-	repoManager := repo.NewManager(workspace)
+	repoManager := repo.NewRepoManager()
 	testUser := os.Getenv("GITHUB_USER")
 	testPassword := os.Getenv("GITHUB_TOKEN")
 	ghRelease, err := repoManager.GetGithubRelease("mevansam", "test-app", "zipball", &testUser, &testPassword)
@@ -65,7 +66,7 @@ func testSourceZipFileDownload(t *testing.T) {
 func testSourceTarFileDownload(t *testing.T) {
 	fmt.Println("Test: source tar file download")
 
-	repoManager := repo.NewManager(workspace)
+	repoManager := repo.NewRepoManager()
 	testUser := os.Getenv("GITHUB_USER")
 	testPassword := os.Getenv("GITHUB_TOKEN")
 	ghRelease, err := repoManager.GetGithubRelease("mevansam", "test-app", "tarball", &testUser, &testPassword)

--- a/cloudfoundry/repo/github_release_test.go
+++ b/cloudfoundry/repo/github_release_test.go
@@ -5,8 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 	"regexp"
 	"testing"
 
@@ -15,15 +13,12 @@ import (
 
 func TestGithubReleaseRepo(t *testing.T) {
 
-	workspace := getGithubReleaseWorkspace()
-	defer os.RemoveAll(workspace)
-
-	testReleaseFileDownload(workspace, t)
-	testSourceZipFileDownload(workspace, t)
-	testSourceTarFileDownload(workspace, t)
+	testReleaseFileDownload(t)
+	testSourceZipFileDownload(t)
+	testSourceTarFileDownload(t)
 }
 
-func testReleaseFileDownload(workspace string, t *testing.T) {
+func testReleaseFileDownload(t *testing.T) {
 	fmt.Println("Test: release file download")
 
 	repoManager := repo.NewManager(workspace)
@@ -31,6 +26,7 @@ func testReleaseFileDownload(workspace string, t *testing.T) {
 	testPassword := os.Getenv("GITHUB_TOKEN")
 	ghRelease, err := repoManager.GetGithubRelease("mevansam", "test-app", "test_release_file.zip", &testUser, &testPassword)
 	checkError(t, err)
+	defer ghRelease.Clean()
 
 	err = ghRelease.SetVersion("v0.0.1", repo.DefaultVersionType)
 	checkError(t, err)
@@ -49,7 +45,7 @@ func testReleaseFileDownload(workspace string, t *testing.T) {
 	}
 }
 
-func testSourceZipFileDownload(workspace string, t *testing.T) {
+func testSourceZipFileDownload(t *testing.T) {
 	fmt.Println("Test: source zip file download")
 
 	repoManager := repo.NewManager(workspace)
@@ -58,6 +54,7 @@ func testSourceZipFileDownload(workspace string, t *testing.T) {
 	ghRelease, err := repoManager.GetGithubRelease("mevansam", "test-app", "zipball", &testUser, &testPassword)
 
 	checkError(t, err)
+	defer ghRelease.Clean()
 
 	err = ghRelease.SetVersion("v0.0.1", repo.DefaultVersionType)
 	checkError(t, err)
@@ -65,7 +62,7 @@ func testSourceZipFileDownload(workspace string, t *testing.T) {
 	validateSourceZip(ghRelease.GetPath(), t)
 }
 
-func testSourceTarFileDownload(workspace string, t *testing.T) {
+func testSourceTarFileDownload(t *testing.T) {
 	fmt.Println("Test: source tar file download")
 
 	repoManager := repo.NewManager(workspace)
@@ -74,6 +71,7 @@ func testSourceTarFileDownload(workspace string, t *testing.T) {
 	ghRelease, err := repoManager.GetGithubRelease("mevansam", "test-app", "tarball", &testUser, &testPassword)
 
 	checkError(t, err)
+	defer ghRelease.Clean()
 
 	err = ghRelease.SetVersion("v0.0.1", repo.DefaultVersionType)
 	checkError(t, err)
@@ -136,20 +134,4 @@ func validateSourceZip(path string, t *testing.T) {
 	}
 
 	t.Fatalf("'README.md' was not found in source archive")
-}
-
-func getGithubReleaseWorkspace() (dir string) {
-
-	var err error
-
-	if dir, err = filepath.Abs(filepath.Dir(os.Args[0])); err == nil {
-
-		dir += "/.test_github_release"
-		if err = os.RemoveAll(dir); err == nil {
-			if err = os.Mkdir(dir, os.ModePerm); err == nil {
-				return
-			}
-		}
-	}
-	panic(err.Error())
 }

--- a/cloudfoundry/repo/repo_manager.go
+++ b/cloudfoundry/repo/repo_manager.go
@@ -26,6 +26,7 @@ const (
 type Repository interface {
 	GetPath() string
 	SetVersion(version string, versionType VersionType) (err error)
+	Clean() error
 }
 
 // RepoManager -

--- a/cloudfoundry/repo/repo_manager.go
+++ b/cloudfoundry/repo/repo_manager.go
@@ -42,7 +42,7 @@ func NewRepoManager() *RepoManager {
 }
 
 // GetGitRepository -
-func (rm *RepoManager) GetGitRepository(repoURL string, user, password, privateKey *string) (repo Repository, err error) {
+func (rm *RepoManager) GetGitRepository(name string, repoURL string, user, password, privateKey *string) (repo Repository, err error) {
 
 	rm.gitMutex.Lock()
 	defer rm.gitMutex.Unlock()
@@ -53,6 +53,8 @@ func (rm *RepoManager) GetGitRepository(repoURL string, user, password, privateK
 	if err != nil {
 		return nil, err
 	}
+
+	p = p + "/" + name
 
 	if user != nil {
 

--- a/cloudfoundry/repo/repo_manager.go
+++ b/cloudfoundry/repo/repo_manager.go
@@ -49,7 +49,7 @@ func (rm *RepoManager) GetGitRepository(repoURL string, user, password, privateK
 
 	var r *git.Repository
 
-	p, err := ioutil.TempDir("", "terraform-provider-cf")
+	p, err := ioutil.TempDir("", "terraform-provider-cloudfoundry")
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func (rm *RepoManager) GetGithubRelease(ghOwner, ghRepoName, archiveName string,
 		return nil, err
 	}
 
-	path, err := ioutil.TempDir("", "terraform-provider-cf")
+	path, err := ioutil.TempDir("", "terraform-provider-cloudfoundry")
 	if err != nil {
 		return nil, err
 	}

--- a/cloudfoundry/resource_cf_app.go
+++ b/cloudfoundry/resource_cf_app.go
@@ -475,7 +475,7 @@ func resourceAppCreate(d *schema.ResourceData, meta interface{}) (err error) {
 				upload <- err
 				return
 			}
-			err = os.Remove(appPath)
+			err = os.RemoveAll(appPath)
 			upload <- err
 		}()
 	}
@@ -704,7 +704,7 @@ func resourceAppUpdate(d *schema.ResourceData, meta interface{}) error {
 			appPath = appPathCalc
 		}
 		defer func() {
-			os.Remove(appPath)
+			os.RemoveAll(appPath)
 		}()
 		if v, ok = d.GetOk("add_content"); ok {
 			addContent = getListOfStructs(v)

--- a/cloudfoundry/resource_cf_app.go
+++ b/cloudfoundry/resource_cf_app.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
 	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/repo"
-	"github.com/prometheus/common/log"
 )
 
 // DefaultAppTimeout - Timeout (in seconds) when pushing apps to CF
@@ -456,7 +455,7 @@ func resourceAppCreate(d *schema.ResourceData, meta interface{}) (err error) {
 		}
 		err = am.DeleteApp(app.ID, true)
 		if err != nil {
-			log.Fatal(err)
+			panic(err)
 		}
 	}()
 

--- a/cloudfoundry/resource_cf_app.go
+++ b/cloudfoundry/resource_cf_app.go
@@ -475,7 +475,18 @@ func resourceAppCreate(d *schema.ResourceData, meta interface{}) (err error) {
 				upload <- err
 				return
 			}
-			err = os.RemoveAll(appPath)
+
+			// Do not remove files from the local file system
+			if v, ok := d.GetOk("url"); ok {
+				url := v.(string)
+
+				if !strings.HasPrefix(url, "file://") {
+					err = os.RemoveAll(appPath)
+				}
+			} else {
+				err = os.RemoveAll(appPath)
+			}
+
 			upload <- err
 		}()
 	}

--- a/cloudfoundry/resource_cf_buildpack.go
+++ b/cloudfoundry/resource_cf_buildpack.go
@@ -161,6 +161,7 @@ func resourceBuildpackCreate(d *schema.ResourceData, meta interface{}) (err erro
 			return err
 		}
 		path = repository.GetPath()
+		defer repository.Clean()
 	}
 	if bp, err = session.BuildpackManager().CreateBuildpack(name, position, enabled, locked, path); err != nil {
 		return err
@@ -247,6 +248,7 @@ func resourceBuildpackUpdate(d *schema.ResourceData, meta interface{}) (err erro
 				return err
 			}
 			path = repository.GetPath()
+			defer repository.Clean()
 		}
 		if bp, err = session.BuildpackManager().UploadBuildpackBits(bp, path); err != nil {
 			return err

--- a/cloudfoundry/resource_cf_route.go
+++ b/cloudfoundry/resource_cf_route.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
-	"github.com/prometheus/common/log"
 )
 
 func resourceRoute() *schema.Resource {
@@ -141,7 +140,7 @@ func resourceRouteCreate(d *schema.ResourceData, meta interface{}) (err error) {
 		}
 		err = rm.DeleteRoute(route.ID)
 		if err != nil {
-			log.Fatal(err)
+			panic(err)
 		}
 	}()
 

--- a/cloudfoundry/resource_cf_route.go
+++ b/cloudfoundry/resource_cf_route.go
@@ -145,13 +145,13 @@ func resourceRouteCreate(d *schema.ResourceData, meta interface{}) (err error) {
 	}()
 
 	if err = setRouteArguments(session, route, d); err != nil {
-		return
+		return err
 	}
 
 	if v, ok := d.GetOk("target"); ok {
 		var t interface{}
 		if t, err = addTargets(route.ID, getListOfStructs(v.(*schema.Set).List()), rm, session.Log); err != nil {
-			return
+			return err
 		}
 		d.Set("target", t)
 		session.Log.DebugMessage("Mapped route targets: %# v", d.Get("target"))

--- a/cloudfoundry/resource_cf_route.go
+++ b/cloudfoundry/resource_cf_route.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/prometheus/common/log"
 )
 
 func resourceRoute() *schema.Resource {
@@ -133,12 +134,15 @@ func resourceRouteCreate(d *schema.ResourceData, meta interface{}) (err error) {
 		return err
 	}
 	// Delete route if an error occurs
-	defer func() error {
+	defer func() {
 		e := &err
-		if *e != nil {
-			return rm.DeleteRoute(route.ID)
+		if *e == nil {
+			return
 		}
-		return nil
+		err = rm.DeleteRoute(route.ID)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}()
 
 	if err = setRouteArguments(session, route, d); err != nil {

--- a/cloudfoundry/utils_repo.go
+++ b/cloudfoundry/utils_repo.go
@@ -11,9 +11,13 @@ var repoManager *repo.RepoManager = repo.NewRepoManager()
 func getRepositoryFromConfig(d *schema.ResourceData) (repository repo.Repository, err error) {
 
 	var (
-		version     string
-		versionType repo.VersionType
+		version, name string
+		versionType   repo.VersionType
 	)
+
+	if v, ok := d.Get("name").(string); ok {
+		name = v
+	}
 
 	if v, ok := d.Get("git").([]interface{}); ok && len(v) > 0 {
 		gitArgs := v[0].(map[string]interface{})
@@ -46,7 +50,7 @@ func getRepositoryFromConfig(d *schema.ResourceData) (repository repo.Repository
 			privateKey = &s
 		}
 
-		if repository, err = repoManager.GetGitRepository(repoURL, user, password, privateKey); err != nil {
+		if repository, err = repoManager.GetGitRepository(name, repoURL, user, password, privateKey); err != nil {
 			return repository, err
 		}
 

--- a/cloudfoundry/utils_repo.go
+++ b/cloudfoundry/utils_repo.go
@@ -1,41 +1,11 @@
 package cloudfoundry
 
 import (
-	"os"
-	"os/user"
-
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/repo"
 )
 
-var repoManager *repo.Manager
-
-// initRepoManager -
-func initRepoManager() error {
-
-	var (
-		usr     *user.User
-		rootDir string
-
-		err error
-	)
-
-	if usr, err = user.Current(); err != nil {
-		return err
-	}
-	if len(usr.HomeDir) == 0 {
-		rootDir = os.TempDir()
-	} else {
-		rootDir = usr.HomeDir
-	}
-
-	workspace := rootDir + "/.terraform.d/provider/cf/repo"
-	if err = os.MkdirAll(workspace, os.ModePerm); err != nil {
-		return err
-	}
-	repoManager = repo.NewManager(workspace)
-	return nil
-}
+var repoManager *repo.RepoManager = repo.NewRepoManager()
 
 // getRepositoryFromConfig -
 func getRepositoryFromConfig(d *schema.ResourceData) (repository repo.Repository, err error) {

--- a/tests/clean.sh
+++ b/tests/clean.sh
@@ -17,6 +17,7 @@ set +e
 cf delete -f php-app
 cf delete -f basic-auth-router
 cf delete -f basic-auth-broker
+cf delete -f fake-service-broker
 cf delete -f test-app
 cf delete -f test-docker-app
 
@@ -44,6 +45,7 @@ cf delete-route -f $CF_TEST_APP_DOMAIN --hostname basic-auth-router
 cf delete-route -f $CF_TEST_APP_DOMAIN --hostname basic-auth-broker
 cf delete-route -f $CF_TEST_APP_DOMAIN --hostname test-app
 cf delete-route -f $CF_TEST_APP_DOMAIN --hostname test-docker-app
+cf delete-route -f $CF_TEST_APP_DOMAIN --hostname fake-service-broker
 cf unbind-route-service -f $CF_TEST_APP_DOMAIN basic-auth --hostname php-app
 
 # Delete users


### PR DESCRIPTION
@mevansam could you do code review please ?

I've removed inside `repo_manager.GetGitRepository` the ability to get back an already git cloned repository as temp directory can't be took again.
I think it's not that much useful as we run terraform on a pipeline so git cloned is anyway always performed. Also, issue #58 address this problem to not download for nothing.

About the cleaning, the way i fix it is definetely not the best way to do so but it seems that I will need to refactor `repo_manager`. Do you share this feeling @mevansam ?