### PR TITLE
always wait at least the appStatePingSleep period before checking on restage status

### DIFF
--- a/cloudfoundry/cfapi/app_manager.go
+++ b/cloudfoundry/cfapi/app_manager.go
@@ -410,6 +410,7 @@ func (am *AppManager) WaitForAppToStage(app CCApp, timeout time.Duration) (err e
 		var err error
 
 		for {
+			time.Sleep(appStatePingSleep)
 			if app, err = am.ReadApp(app.ID); err != nil {
 				c <- err
 				return
@@ -424,7 +425,6 @@ func (am *AppManager) WaitForAppToStage(app CCApp, timeout time.Duration) (err e
 					return
 				}
 			}
-			time.Sleep(appStatePingSleep)
 		}
 	}()
 


### PR DESCRIPTION


In rare instances, it is possible that the read API call on an application
does not yet reflect the updated package state of the application
immediately and this causes a short circuit in the restage wait logic which
can ultimately end up with the provider reporting success too early, or
sucess when the restage actually will eventually fail, or even result in
an error indicating that the application crashed.  It all depends on the
application's state prior to the restage.  The fix, hopefully, is to always
pause for at least the regular polling cycle wait time before doing the
first status check to give Cloud Foundry enough time to return the correct
values from the read API.