### PR TITLE
correct service_binding attributes in cloudfoundry_app parmeters

### DIFF
--- a/website/docs/r/app.html.markdown
+++ b/website/docs/r/app.html.markdown
@@ -79,7 +79,7 @@ One of the following arguments must be declared to locate application source or 
 
 * `service_binding` - (Optional, Array) Service instances to bind to the application.
 
-  - `service` - (Required, String) The service instance GUID.
+  - `service_instance` - (Required, String) The service instance GUID.
   - `params` - (Optional, Map) A list of key/value parameters used by the service broker to create the binding.
 
 ~> **NOTE:** Modifying this argument will cause the application to be restaged.   


### PR DESCRIPTION
The provider expects `service_binding` not `service`.