### PR TITLE
additional touchups after merging docker container support

### DIFF
--- a/cloudfoundry/resource_cf_app_test.go
+++ b/cloudfoundry/resource_cf_app_test.go
@@ -471,7 +471,7 @@ func TestAccApp_dockerApp(t *testing.T) {
 
 				resource.TestStep{
 					Config: fmt.Sprintf(appResourceDocker, defaultAppDomain()),
-					Check: resource.ComposeTestCheckFunc(
+					Check: resource.ComposeAggregateTestCheckFunc(
 						testAccCheckAppExists(refApp, func() (err error) {
 
 							if err = assertHTTPResponse("https://test-docker-app."+defaultAppDomain(), 200, nil); err != nil {


### PR DESCRIPTION
- ensure add_content conflicts with docker containers
- force a new resource in the case of changing an app to/from
  the docker container type, and try to ensure this will work (not tested!)
- cleanup in the resourceAppUpdate am.UpdateApp section
- ensure changes to the docker_credentials block are pushed
- mark docker_credentials as sensitive so they are not displayed in the log
- misc comment cleanup