### PR TITLE
improve handling of cf_app binary updates

### DIFF
--- a/cloudfoundry/cfapi/app_manager.go
+++ b/cloudfoundry/cfapi/app_manager.go
@@ -458,6 +458,11 @@ func (am *AppManager) StopApp(appID string, timeout time.Duration) (err error) {
 	if app, err = am.ReadApp(appID); err != nil {
 		return err
 	}
+	// set to DockerCredentials = nil if this is not a docker image
+	if app.DockerImage == nil {
+		app.DockerCredentials = nil
+	}
+
 	if app.State != nil && *app.State == AppStarted {
 		app.State = &AppStopped
 		if app, err = am.UpdateApp(app); err != nil {

--- a/cloudfoundry/resource_cf_app.go
+++ b/cloudfoundry/resource_cf_app.go
@@ -387,7 +387,6 @@ func resourceAppCreate(d *schema.ResourceData, meta interface{}) (err error) {
 	if v, ok = d.GetOk("docker_image"); ok {
 		vv := v.(string)
 		app.DockerImage = &vv
-
 		// Activate Diego for Docker
 		onDiego := true
 		app.Diego = &onDiego

--- a/cloudfoundry/resource_cf_app_test.go
+++ b/cloudfoundry/resource_cf_app_test.go
@@ -471,7 +471,7 @@ func TestAccApp_dockerApp(t *testing.T) {
 
 				resource.TestStep{
 					Config: fmt.Sprintf(appResourceDocker, defaultAppDomain()),
-					Check: resource.ComposeTestCheckFunc(
+					Check: resource.ComposeAggregateTestCheckFunc(
 						testAccCheckAppExists(refApp, func() (err error) {
 
 							if err = assertHTTPResponse("https://test-docker-app."+defaultAppDomain(), 200, nil); err != nil {


### PR DESCRIPTION
Cloud Foundry marks an application's package_state as pending whenever a a new binary is uploaded.
This leads to calls to the restage endpoint actually throwing an error instead of prompting immediate
restaging.  The CF CLI actually forces an immediate restage by restarting the application.  Thus this is
what we will now do.

This PR replaces #79, and thus all of the improvements discussed there are also now included here.