### PR TITLE
Fix service binding

### DIFF
--- a/cloudfoundry/resource_cf_app.go
+++ b/cloudfoundry/resource_cf_app.go
@@ -999,8 +999,6 @@ func addServiceBindings(
 	var (
 		serviceInstanceID, bindingID string
 		params                       *map[string]interface{}
-		credentials                  map[string]interface{}
-		bindingCredentials           map[string]interface{}
 	)
 
 	for _, b := range add {
@@ -1010,15 +1008,10 @@ func addServiceBindings(
 			vv := v.(map[string]interface{})
 			params = &vv
 		}
-		if bindingID, bindingCredentials, err = am.CreateServiceBinding(id, serviceInstanceID, params); err != nil {
+		if bindingID, _, err = am.CreateServiceBinding(id, serviceInstanceID, params); err != nil {
 			return bindings, err
 		}
 		b["binding_id"] = bindingID
-
-		credentials = b["credentials"].(map[string]interface{})
-		for k, v := range normalizeMap(bindingCredentials, make(map[string]interface{}), "", "_") {
-			credentials[k] = v
-		}
 
 		bindings = append(bindings, b)
 		log.DebugMessage("Created binding with id '%s' for service instance '%s'.", bindingID, serviceInstanceID)

--- a/cloudfoundry/resource_cf_app_test.go
+++ b/cloudfoundry/resource_cf_app_test.go
@@ -600,12 +600,6 @@ func testAccCheckAppExists(resApp string, validate func() error) resource.TestCh
 				}
 
 				if binding != nil && values["binding_id"] == binding["binding_id"] {
-					if err2 := assertMapEquals("credentials", values, binding["credentials"].(map[string]interface{})); err2 != nil {
-						session.Log.LogMessage(
-							"Credentials for service instance %s do not match: %s",
-							serviceInstanceID, err2.Error())
-						return false
-					}
 					return true
 				}
 				return false


### PR DESCRIPTION
When service binding was associated, credentials was given to resource.

This has been removed on previous PR but settings credentials in resource was still there.

This PR remove this code.