### PR TITLE
Dev website validate

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,7 @@
 TEST?=$$(go list ./... |grep -v 'vendor')
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
+WEBSITE_REPO=github.com/hashicorp/terraform-website
+PKG_NAME=cloudfoundry
 
 default: build
 
@@ -38,4 +40,19 @@ test-compile:
 	fi
 	go test -c $(TEST) $(TESTARGS)
 
-.PHONY: build test testacc fmt check vendor-status test-compile
+website:
+ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
+	echo "$(WEBSITE_REPO) not found in your GOPATH (necessary for layouts and assets), get-ting..."
+	git clone https://$(WEBSITE_REPO) $(GOPATH)/src/$(WEBSITE_REPO)
+endif
+	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
+
+website-test:
+ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
+	echo "$(WEBSITE_REPO) not found in your GOPATH (necessary for layouts and assets), get-ting..."
+	git clone https://$(WEBSITE_REPO) $(GOPATH)/src/$(WEBSITE_REPO)
+endif
+	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
+
+
+.PHONY: build test testacc fmt check vendor-status test-compile website website-test

--- a/website/cloudfoundry.erb
+++ b/website/cloudfoundry.erb
@@ -9,44 +9,44 @@
 			</li>
 
 			<li<%= sidebar_current("docs-cf-index") %>>
-			<a href="/docs/providers/cf/index.html">Cloud Foundry Provider</a>
+			<a href="/docs/providers/cloudfoundry/index.html">Cloud Foundry Provider</a>
 			</li>
 
 			<li<%= sidebar_current("docs-cf-datasource") %>>
 				<a href="#">Data Sources</a>
 				<ul class="nav nav-visible">
 					<li<%= sidebar_current("docs-cf-datasource-info") %>>
-					<a href="/docs/providers/cf/d/info.html">cloudfoundry_info</a>
+					<a href="/docs/providers/cloudfoundry/d/info.html">cloudfoundry_info</a>
 					</li>
 					<li<%= sidebar_current("docs-cf-datasource-stack") %>>
-					<a href="/docs/providers/cf/d/stack.html">cloudfoundry_stack</a>
+					<a href="/docs/providers/cloudfoundry/d/stack.html">cloudfoundry_stack</a>
 					</li>
 					<li<%= sidebar_current("docs-cf-datasource-router-group") %>>
-					<a href="/docs/providers/cf/d/router_group.html">cloudfoundry_router_group</a>
+					<a href="/docs/providers/cloudfoundry/d/router_group.html">cloudfoundry_router_group</a>
 					</li>
 					<li<%= sidebar_current("docs-cf-datasource-domain") %>>
-					<a href="/docs/providers/cf/d/domain.html">cloudfoundry_domain</a>
+					<a href="/docs/providers/cloudfoundry/d/domain.html">cloudfoundry_domain</a>
 					</li>
 					<li<%= sidebar_current("docs-cf-datasource-asg") %>>
-					<a href="/docs/providers/cf/d/asg.html">cloudfoundry_asg</a>
+					<a href="/docs/providers/cloudfoundry/d/asg.html">cloudfoundry_asg</a>
 					</li>
 					<li<%= sidebar_current("docs-cf-datasource-org-quota") %>>
-					<a href="/docs/providers/cf/d/org_quota.html">cloudfoundry_org_quota</a>
+					<a href="/docs/providers/cloudfoundry/d/org_quota.html">cloudfoundry_org_quota</a>
 					</li>
 					<li<%= sidebar_current("docs-cf-datasource-space-quota") %>>
-					<a href="/docs/providers/cf/d/space_quota.html">cloudfoundry_space_quota</a>
+					<a href="/docs/providers/cloudfoundry/d/space_quota.html">cloudfoundry_space_quota</a>
 					</li>
 					<li<%= sidebar_current("docs-cf-datasource-user") %>>
-					<a href="/docs/providers/cf/d/user.html">cloudfoundry_user</a>
+					<a href="/docs/providers/cloudfoundry/d/user.html">cloudfoundry_user</a>
 					</li>
 					<li<%= sidebar_current("docs-cf-datasource-org") %>>
-					<a href="/docs/providers/cf/d/org.html">cloudfoundry_org</a>
+					<a href="/docs/providers/cloudfoundry/d/org.html">cloudfoundry_org</a>
 					</li>
 					<li<%= sidebar_current("docs-cf-datasource-space") %>>
-					<a href="/docs/providers/cf/d/space.html">cloudfoundry_space</a>
+					<a href="/docs/providers/cloudfoundry/d/space.html">cloudfoundry_space</a>
 					</li>
 					<li<%= sidebar_current("docs-cf-datasource-service") %>>
-					<a href="/docs/providers/cf/d/service.html">cloudfoundry_service</a>
+					<a href="/docs/providers/cloudfoundry/d/service.html">cloudfoundry_service</a>
 					</li>
 				</ul>
 			</li>
@@ -55,62 +55,62 @@
 				<a href="#">Resources</a>
 				<ul class="nav nav-visible">
 					<li<%= sidebar_current("docs-cf-resource-config") %>>
-					<a href="/docs/providers/cf/r/config.html">cloudfoundry_config</a>
+					<a href="/docs/providers/cloudfoundry/r/config.html">cloudfoundry_config</a>
 					</li>
 					<li<%= sidebar_current("docs-cf-resource-user") %>>
-					<a href="/docs/providers/cf/r/user.html">cloudfoundry_user</a>
+					<a href="/docs/providers/cloudfoundry/r/user.html">cloudfoundry_user</a>
 					</li>
 					<li<%= sidebar_current("docs-cf-resource-domain") %>>
-					<a href="/docs/providers/cf/r/domain.html">cloudfoundry_domain</a>
+					<a href="/docs/providers/cloudfoundry/r/domain.html">cloudfoundry_domain</a>
 					</li>
 					<li<%= sidebar_current("docs-cf-resource-evg") %>>
-					<a href="/docs/providers/cf/r/evg.html">cloudfoundry_evg</a>
+					<a href="/docs/providers/cloudfoundry/r/evg.html">cloudfoundry_evg</a>
 					</li>
 					<li<%= sidebar_current("docs-cf-resource-asg") %>>
-					<a href="/docs/providers/cf/r/asg.html">cloudfoundry_asg</a>
+					<a href="/docs/providers/cloudfoundry/r/asg.html">cloudfoundry_asg</a>
 					</li>
 					<li<%= sidebar_current("docs-cf-resource-default-asg") %>>
-					<a href="/docs/providers/cf/r/default_asg.html">cloudfoundry_default_asg</a>
+					<a href="/docs/providers/cloudfoundry/r/default_asg.html">cloudfoundry_default_asg</a>
 					</li>
 					<li<%= sidebar_current("docs-cf-resource-org-quota") %>>
-					<a href="/docs/providers/cf/r/org_quota.html">cloudfoundry_org_quota</a>
+					<a href="/docs/providers/cloudfoundry/r/org_quota.html">cloudfoundry_org_quota</a>
 					</li>
-                                        <li<%= sidebar_current("docs-cf-resource-space-quota") %>>
-					<a href="/docs/providers/cf/r/space_quota.html">cloudfoundry_space_quota</a>
+          <li<%= sidebar_current("docs-cf-resource-space-quota") %>>
+					<a href="/docs/providers/cloudfoundry/r/space_quota.html">cloudfoundry_space_quota</a>
 					</li>
 					<li<%= sidebar_current("docs-cf-resource-org") %>>
-					<a href="/docs/providers/cf/r/org.html">cloudfoundry_org</a>
+					<a href="/docs/providers/cloudfoundry/r/org.html">cloudfoundry_org</a>
 					</li>
 					<li<%= sidebar_current("docs-cf-resource-space") %>>
-					<a href="/docs/providers/cf/r/space.html">cloudfoundry_space</a>
+					<a href="/docs/providers/cloudfoundry/r/space.html">cloudfoundry_space</a>
 					</li>
 					<li<%= sidebar_current("docs-cf-resource-service-broker") %>>
-					<a href="/docs/providers/cf/r/service_broker.html">cloudfoundry_service_broker</a>
+					<a href="/docs/providers/cloudfoundry/r/service_broker.html">cloudfoundry_service_broker</a>
 					</li>
 					<li<%= sidebar_current("docs-cf-resource-service-access") %>>
-					<a href="/docs/providers/cf/r/service_plan_access.html">cloudfoundry_service_plan_access</a>
+					<a href="/docs/providers/cloudfoundry/r/service_plan_access.html">cloudfoundry_service_plan_access</a>
 					</li>
 					<li<%= sidebar_current("docs-cf-resource-service-instance") %>>
-					<a href="/docs/providers/cf/r/service_instance.html">cloudfoundry_service_instance</a>
+					<a href="/docs/providers/cloudfoundry/r/service_instance.html">cloudfoundry_service_instance</a>
 					</li>
 					<li<%= sidebar_current("docs-cf-resource-service-key") %>>
-					<a href="/docs/providers/cf/r/service_key.html">cloudfoundry_service_key</a>
+					<a href="/docs/providers/cloudfoundry/r/service_key.html">cloudfoundry_service_key</a>
 					</li>
 					<li<%= sidebar_current("docs-cf-resource-user-provided-service") %>>
-					<a href="/docs/providers/cf/r/user_provided_service.html">cloudfoundry_user_provided_service</a>
+					<a href="/docs/providers/cloudfoundry/r/user_provided_service.html">cloudfoundry_user_provided_service</a>
 					</li>
 					<li<%= sidebar_current("docs-cf-resource-buildpack") %>>
-					<a href="/docs/providers/cf/r/buildpack.html">cloudfoundry_buildpack</a>
+					<a href="/docs/providers/cloudfoundry/r/buildpack.html">cloudfoundry_buildpack</a>
 					</li>
 					<li<%= sidebar_current("docs-cf-resource-route") %>>
-					<a href="/docs/providers/cf/r/route.html">cloudfoundry_route</a>
+					<a href="/docs/providers/cloudfoundry/r/route.html">cloudfoundry_route</a>
 					</li>
 					<li<%= sidebar_current("docs-cf-resource-app") %>>
-					<a href="/docs/providers/cf/r/app.html">cloudfoundry_app</a>
+					<a href="/docs/providers/cloudfoundry/r/app.html">cloudfoundry_app</a>
 					</li>
 					<!--
 					<li<%= sidebar_current("docs-cf-resource-service-binding") %>>
-					<a href="/docs/providers/cf/r/service_binding.html">cloudfoundry_service_binding</a>
+					<a href="/docs/providers/cloudfoundry/r/service_binding.html">cloudfoundry_service_binding</a>
 					</li>
 					-->
 				</ul>

--- a/website/docs/d/space_quota.html.markdown
+++ b/website/docs/d/space_quota.html.markdown
@@ -1,5 +1,5 @@
 ---
-layout: "cf"
+layout: "cloudfoundry"
 page_title: "Cloud Foundry: cloudfoundry_space_quota"
 sidebar_current: "docs-cf-datasource-space-quota"
 description: |-

--- a/website/docs/r/app.html.markdown
+++ b/website/docs/r/app.html.markdown
@@ -30,9 +30,9 @@ The following arguments are supported:
 * `instances` - (Optional, Number) The number of app instances that you want to start. Defaults to 1.
 * `memory` - (Optional, Number) The memory limit for each application instance in megabytes. If not provided, value is computed and retreived from Cloud Foundry.
 * `disk_quota` - (Optional, Number) The disk space to be allocated for each application instance in megabytes. If not provided, default disk quota is retrieved from Cloud Foundry and assigned.
-* `stack` - (Optional) The GUID of the stack the application will be deployed to. Use the [`cloudfoundry_stack`](/docs/providers/cf/d/stack.html) data resource to lookup the stack GUID to override Cloud Foundry default.
+* `stack` - (Optional) The GUID of the stack the application will be deployed to. Use the [`cloudfoundry_stack`](/docs/providers/cloudfoundry/d/stack.html) data resource to lookup the stack GUID to override Cloud Foundry default.
 * `buildpack` - (Optional, String) The buildpack used to stage the application. There are multiple options to choose from:
-   * a Git URL (e.g. https://github.com/cloudfoundry/java-buildpack.git) or a Git URL with a branch or tag (e.g. https://github.com/cloudfoundry/java-buildpack.git#v3.3.0 for v3.3.0 tag) 
+   * a Git URL (e.g. https://github.com/cloudfoundry/java-buildpack.git) or a Git URL with a branch or tag (e.g. https://github.com/cloudfoundry/java-buildpack.git#v3.3.0 for v3.3.0 tag)
    * an installed admin buildpack name (e.g. my-buildpack)
    * an empty blank string to use built-in buildpacks (i.e. autodetection)
 * `command` - (Optional, String) A custom start command for the application. This overrides the start command provided by the buildpack.
@@ -46,11 +46,11 @@ One of the following arguments must be declared to locate application source or 
 
 * `url` - (Optional, String) The URL for the application binary. A local path may be referenced via "`file://...`".
 
-* `docker_image` - (Optional, String) The URL to the docker image with tag e.g registry.example.com:5000/user/repository/tag or docker image name from the public repo e.g. redis:4.0 
-* `docker_credentials` - (Optional) Defines login credentials for private docker repositories 
-  - `username` - (Required, String) Username for the private docker repo 
-  - `password` - (Required, String) Password for the private docker repo 
- 
+* `docker_image` - (Optional, String) The URL to the docker image with tag e.g registry.example.com:5000/user/repository/tag or docker image name from the public repo e.g. redis:4.0
+* `docker_credentials` - (Optional) Defines login credentials for private docker repositories
+  - `username` - (Required, String) Username for the private docker repo
+  - `password` - (Required, String) Password for the private docker repo
+
 * `git` - (Optional, String) The git repository where to pull the application source from.
 
   - `url` - (Required, String) The git URL for the application repository.
@@ -87,12 +87,12 @@ One of the following arguments must be declared to locate application source or 
 
 ### Routing
 
-* `route` - (Optional) Configures how the application will be accessed externally to cloudfoundry. 
+* `route` - (Optional) Configures how the application will be accessed externally to cloudfoundry.
   - `default_route` - (Optional, String) The ID of the route where the application will be reachable from once deployed.
 
 ### Environment Variables
 
-* `environment` - (Optional, Map) Key/value pairs of custom environment variables to set in your app. Does not include any [system or service variables](http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#app-system-env). 
+* `environment` - (Optional, Map) Key/value pairs of custom environment variables to set in your app. Does not include any [system or service variables](http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#app-system-env).
 
 ~> **NOTE:** Modifying this argument will cause the application to be restaged.
 
@@ -115,4 +115,3 @@ The current App can be imported using the `app` GUID, e.g.
 ```
 $ terraform import cloudfoundry_app.spring-music a-guid
 ```
-

--- a/website/docs/r/app.html.markdown
+++ b/website/docs/r/app.html.markdown
@@ -32,7 +32,7 @@ The following arguments are supported:
 * `disk_quota` - (Optional, Number) The disk space to be allocated for each application instance in megabytes. If not provided, default disk quota is retrieved from Cloud Foundry and assigned.
 * `stack` - (Optional) The GUID of the stack the application will be deployed to. Use the [`cloudfoundry_stack`](/docs/providers/cloudfoundry/d/stack.html) data resource to lookup the stack GUID to override Cloud Foundry default.
 * `buildpack` - (Optional, String) The buildpack used to stage the application. There are multiple options to choose from:
-   * a Git URL (e.g. https://github.com/cloudfoundry/java-buildpack.git) or a Git URL with a branch or tag (e.g. https://github.com/cloudfoundry/java-buildpack.git#v3.3.0 for v3.3.0 tag)
+   * a Git URL (e.g. https://github.com/cloudfoundry/java-buildpack.git) or a Git URL with a branch or tag (e.g. https://github.com/cloudfoundry/java-buildpack.git#v3.3.0 for v3.3.0 tag) 
    * an installed admin buildpack name (e.g. my-buildpack)
    * an empty blank string to use built-in buildpacks (i.e. autodetection)
 * `command` - (Optional, String) A custom start command for the application. This overrides the start command provided by the buildpack.
@@ -46,11 +46,11 @@ One of the following arguments must be declared to locate application source or 
 
 * `url` - (Optional, String) The URL for the application binary. A local path may be referenced via "`file://...`".
 
-* `docker_image` - (Optional, String) The URL to the docker image with tag e.g registry.example.com:5000/user/repository/tag or docker image name from the public repo e.g. redis:4.0
-* `docker_credentials` - (Optional) Defines login credentials for private docker repositories
-  - `username` - (Required, String) Username for the private docker repo
-  - `password` - (Required, String) Password for the private docker repo
-
+* `docker_image` - (Optional, String) The URL to the docker image with tag e.g registry.example.com:5000/user/repository/tag or docker image name from the public repo e.g. redis:4.0 
+* `docker_credentials` - (Optional) Defines login credentials for private docker repositories 
+  - `username` - (Required, String) Username for the private docker repo 
+  - `password` - (Required, String) Password for the private docker repo 
+ 
 * `git` - (Optional, String) The git repository where to pull the application source from.
 
   - `url` - (Required, String) The git URL for the application repository.
@@ -87,12 +87,12 @@ One of the following arguments must be declared to locate application source or 
 
 ### Routing
 
-* `route` - (Optional) Configures how the application will be accessed externally to cloudfoundry.
+* `route` - (Optional) Configures how the application will be accessed externally to cloudfoundry. 
   - `default_route` - (Optional, String) The ID of the route where the application will be reachable from once deployed.
 
 ### Environment Variables
 
-* `environment` - (Optional, Map) Key/value pairs of custom environment variables to set in your app. Does not include any [system or service variables](http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#app-system-env).
+* `environment` - (Optional, Map) Key/value pairs of custom environment variables to set in your app. Does not include any [system or service variables](http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#app-system-env). 
 
 ~> **NOTE:** Modifying this argument will cause the application to be restaged.
 

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -8,12 +8,12 @@ description: |-
 
 # cf\_domain
 
-Provides a resource for managing shared or private 
+Provides a resource for managing shared or private
 [domains](https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#domains) in Cloud Foundry.
 
 ## Example Usage
 
-The following is an example of a shared domain for a sub-domain of the default application domain 
+The following is an example of a shared domain for a sub-domain of the default application domain
 retrieved via a [domain data source](/docs/providers/cloudfoundry/d/domain.html).
 
 ```
@@ -32,20 +32,20 @@ resource "cloudfoundry_domain" "private" {
 }
 ```
 
-~> **NOTE:** To control sharing of a private domain, use the [cloudfoundry_private_domain](private_domain_access.html) resource. 
+~> **NOTE:** To control sharing of a private domain, use the [cloudfoundry_private_domain](private_domain_access.html) resource.
 
 
 ## Argument Reference
 
 The following arguments are supported:
 
-* `name` - (Optional, String) Full name of domain. If specified then the `sub_domain` and `domain` attributes will be computed from the `name` 
+* `name` - (Optional, String) Full name of domain. If specified then the `sub_domain` and `domain` attributes will be computed from the `name`
 * `sub_domain` - (Optional, String) Sub-domain part of full domain name. If specified the `domain` argument needs to be provided and the `name` will be computed.
 * `domain` - (Optional, String) Domain part of full domain name. If specified the `sub_domain` argument needs to be provided and the `name` will be computed.
 
 The following argument applies only to shared domains.
 
-* `router_group` - (Optional, String) The router group GUID, which can be retrieved via the [`cloudfoundry_router_group`](/docs/providers/cf/d/stack.html) data resource. You would need to provide this when creating a shared domain for TCP routes.
+* `router_group` - (Optional, String) The router group GUID, which can be retrieved via the [`cloudfoundry_router_group`](/docs/providers/cloudfoundry/d/stack.html) data resource. You would need to provide this when creating a shared domain for TCP routes.
 
 The following argument applies only to private domains.
 

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -8,12 +8,12 @@ description: |-
 
 # cf\_domain
 
-Provides a resource for managing shared or private
+Provides a resource for managing shared or private 
 [domains](https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#domains) in Cloud Foundry.
 
 ## Example Usage
 
-The following is an example of a shared domain for a sub-domain of the default application domain
+The following is an example of a shared domain for a sub-domain of the default application domain 
 retrieved via a [domain data source](/docs/providers/cloudfoundry/d/domain.html).
 
 ```
@@ -32,14 +32,14 @@ resource "cloudfoundry_domain" "private" {
 }
 ```
 
-~> **NOTE:** To control sharing of a private domain, use the [cloudfoundry_private_domain](private_domain_access.html) resource.
+~> **NOTE:** To control sharing of a private domain, use the [cloudfoundry_private_domain](private_domain_access.html) resource. 
 
 
 ## Argument Reference
 
 The following arguments are supported:
 
-* `name` - (Optional, String) Full name of domain. If specified then the `sub_domain` and `domain` attributes will be computed from the `name`
+* `name` - (Optional, String) Full name of domain. If specified then the `sub_domain` and `domain` attributes will be computed from the `name` 
 * `sub_domain` - (Optional, String) Sub-domain part of full domain name. If specified the `domain` argument needs to be provided and the `name` will be computed.
 * `domain` - (Optional, String) Domain part of full domain name. If specified the `sub_domain` argument needs to be provided and the `name` will be computed.
 

--- a/website/docs/r/org_quota.html.markdown
+++ b/website/docs/r/org_quota.html.markdown
@@ -1,5 +1,5 @@
 ---
-layout: "cf"
+layout: "cloudfoundry"
 page_title: "Cloud Foundry: cloudfoundry_org_quota"
 sidebar_current: "docs-cf-resource-org-quota"
 description: |-

--- a/website/docs/r/route.html.markdown
+++ b/website/docs/r/route.html.markdown
@@ -43,7 +43,7 @@ The following maps the route to an application.
 
 - `target` - (Optional) A route mapping that will map this route to an application
 
-  - `app` - (Required, String) The ID of the [application](/docs/providers/cf/r/app.html) to map this route to.
+  - `app` - (Required, String) The ID of the [application](/docs/providers/cloudfoundry/r/app.html) to map this route to.
   - `port` - (Optional, Int) A port that the application will be listening on. If this argument is not provided then the route will be associated with the application's default port.
 
 ## Attributes Reference

--- a/website/docs/r/service_instance.html.markdown
+++ b/website/docs/r/service_instance.html.markdown
@@ -31,7 +31,7 @@ resource "cloudfoundry_service_instance" "redis1" {
 The following arguments are supported:
 
 * `name` - (Required, String) The name of the Service Instance in Cloud Foundry
-* `service_plan` - (Required, String) The ID of the [service plan](/docs/providers/cloudfoundry/d/service_plan.html)
+* `service_plan` - (Required, String) The ID of the [service plan](/docs/providers/cloudfoundry/d/service.html)
 * `space` - (Required, String) The ID of the [space](/docs/providers/cloudfoundry/r/space.html) 
 * `json_params` - (Optional, String) Json string of arbitrary parameters. Some services support providing additional configuration parameters within the provision request. By default, no params are provided.
 * `tags` - (Optional, List) List of instance tags. Some services provide a list of tags that Cloud Foundry delivers in [VCAP_SERVICES Env variables](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES). By default, no tags are assigned.

--- a/website/docs/r/space.html.markdown
+++ b/website/docs/r/space.html.markdown
@@ -45,7 +45,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the Space in Cloud Foundry.
 * `org` - (Required) The ID of the [Org](/docs/providers/cloudfoundry/r/org.html) within which to create the space.
-* `quota` - (Optional) The ID of the Space [quota](/docs/providers/cloudfoundry/r/quota.html) or plan defined for the owning Org. Specifying an empty string requests unassigns any space quota from the space. Defaults to empty string.
+* `quota` - (Optional) The ID of the Space [quota](/docs/providers/cloudfoundry/r/space_quota.html) or plan defined for the owning Org. Specifying an empty string requests unassigns any space quota from the space. Defaults to empty string.
 * `allow_ssh` - (Optional) Allows SSH to application containers via the [CF CLI](https://github.com/cloudfoundry/cli). Defaults to true.
 * `asgs` - (Optional) List of running [application security groups](/docs/providers/cloudfoundry/r/asg.html) to apply to applications running within this space. Defaults to empty list.
 * `staging_asgs` - (Optional) List of staging [application security groups](/docs/providers/cloudfoundry/r/asg.html) to apply to applications being staged for this space. Defaults to empty list.


### PR DESCRIPTION
Made following changes:

- add `make website` and `make website-test` to makefile;
- change the name of layout file from 'cf' to 'cloudfoundry';
- fix a few broken links;
- two links missing 
  - /docs/providers/cloudfoundry/d/service_plan.html in service_instance.html -> still missing
  - /docs/providers/cloudfoundry/r/quota.html in space.html -> fix to space_quota.html

What need to be done:

- add symbolic links of our layout and doc folder to [terraform-website](https://github.com/hashicorp/terraform-website) (I will send PR from my fork repo)
- add `make website-test` to travis-ci (after merging to terraform-website master, I will send another PR)
