### PR TITLE
Rename 'cf' to 'cloudfoundry', resolve related import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ website/node_modules
 
 
 website/vendor
-/terraform-provider-cf
+/terraform-provider-cloudfoundry
 
 # Test exclusions
 !command/test-fixtures/**/*.tfstate

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 language: go
 go:
 - 1.9.x
-go_import_path: github.com/terraform-providers/terraform-provider-cf
+go_import_path: github.com/terraform-providers/terraform-provider-cloudfoundry
 before_install:
 - curl https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
 - echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
@@ -21,14 +21,14 @@ deploy:
   api_key:
     secure: FV+O96XUOzliHe1V5ycA6WG1UhZe2UOMWtwlct5X+iHezw/EETyAhVzi/s5Zzs3Nj409k48tF3glRFa8LlgI1NRWMOCRU0Uu/RPySBUJvun74sX1siCMTZdYKUSC0RwlgDCOHrB0LGpeuP0XDB/PTUzYweEnxlBS2rk8X1gEgOgw7GIUzGtQBNROQ6xTfUcFUovDWLmOEHegfCb5ZjpYPi2BOIHg9xju/VvmJTflFSMP210QE+SBWpA+P4lHiwXXkaDqQRnDMHVFYFA8ul2jucrTNhMuKPM/rsKyGF2+HMUWu0g3zzGJI8W3Zp8RoVa+eS4DywbtiLvthG/mNh9o8a0HINgyTQfoO7dZega2WNDO4eT+VsgQohn60gTWIk3JJhyAWPPy8nUuY3MWTOgLQicQjInUqvcpV+8BvpBjFjFVkJ+TrL8eJSWbvyGuoqC1dINRJNjZ6343IXIcw4lMMt8fJbwJ8OJCd2av1JMcw8JZPTXjy76H/ENiPwTVegifxZ4h8VeVyG88IHDMZsseqY33cFeYF3T2qkHzbkl2oWD8IgXuCsR4HEw7kffjEp5cS/qdDNGC5IeBfDObrMfcYGu9kX5QlSirBrD/ld0dcQ8t4Y3FhJN+xt5IWp6anqUaCpYwNVA6rGQ9ItozrVFkuGy5t735O/sv6rB05IgBbqQ=
   file:
-  - bin/terraform-provider-cf_windows_amd64.exe
-  - bin/terraform-provider-cf_linux_amd64
-  - bin/terraform-provider-cf_darwin_amd64
+  - bin/terraform-provider-cloudfoundry_windows_amd64.exe
+  - bin/terraform-provider-cloudfoundry_linux_amd64
+  - bin/terraform-provider-cloudfoundry_darwin_amd64
   skip_cleanup: true
   on:
     tags: true
     all_branches: true
-    repo: mevansam/terraform-provider-cf
+    repo: mevansam/terraform-provider-cloudfoundry
 env:
   global:
   - secure: p6gp7WQUOgEv9i4icYiW99gJAPV3Lg7QC9jKsc2xebw3qHPgwU81KNHcc69kdjgR2tKIANSU4fbAIfbkqmaAIFQU8h0+scMjUq4Y8AuJo0/4wCroVRbQKY85wcciQkDm91qinVWR64wGSth6PYVNRz7I+iWWP3uxkj/d2MSiiU2THGJQdBuIucyFfKNFC5cnYRXUePMv28DzCPceblKy9GYfXKv3lvNSoKWVg+gHOCH1o0KNmrh4mjaYugPmikcbOgdGCb9mXos8DSmWXCSfCMbLWAsbCfO8yD06ltriG5hBKvjVfp6Q4RZDZVYJ33XuGlDmhdCiJxwEZ8jC1y0lMgSAQd+mjY2jdTQn1lncDD4RstuSaVw9Y+6B0sK4d6ZaYe8QciWACQExROYc+AykCk1P6gFCBt8Io9IZ+vMyMzYUrUsVEyJrgSVbWFZ0FmifblfYtorKq3LC0jtTrkpieTiUotNbasPfVfQ3lbODhJ2Rv26FA1wuUUk4viIcdHw1UwL3cJ5e5VILVBy12mFE1KkbkKjKkHkEfJwtz+8tOVpJJw5lNvB18Fz9d2wyaAI7Z7yIw2pBYTgyevT8a+Id1GaniFAisFVCKmGdgSC77RacDG38QOYSLfrZBNKzTOdtawG5e5/3juBa0oWowQrDwUWcLn5A1p+oSm6mkiayUuY=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 
-The backlog is kept as github issues annotated with labels and milestones, and progress is tracked in the [backlog project](https://github.com/mevansam/terraform-provider-cf/projects/1).
+The backlog is kept as github issues annotated with labels and milestones, and progress is tracked in the [backlog project](https://github.com/mevansam/terraform-provider-cloudfoundry/projects/1).
 
 Please send PR against the `dev` branches.
 
@@ -11,7 +11,7 @@ Linters are run as part of the travis build. Detected flaws will prevent the mer
 
 Contributors can run the same checks locally by following the procedure:
 
-1. install dependencies 
+1. install dependencies
 
   ```bash
   # install gometalinter tool
@@ -25,12 +25,12 @@ Contributors can run the same checks locally by following the procedure:
   ```bash
   make check
   ```
-  
+
 Fine tuning of the linters configuration can be done in the [.gometalinter.json](.gometalinter.json) file according to the tool [specification](https://github.com/alecthomas/gometalinter#configuration-file)
 
-## Creating a release 
+## Creating a release
 
 * Open up an issue "cutting release 0.9.9" to gather contributors concensus on when to cut the release
 * On your clone, checkout the `dev` branch, and execute `scripts/create-release.sh 0.9.9`
-* travis build kicks off for this tag, and tries to publish the artifacts github, check it on [travis the branch list](https://travis-ci.org/mevansam/terraform-provider-cf/branches)
-* edit the release notes in the [github release page](https://github.com/mevansam/terraform-provider-cf/releases)
+* travis build kicks off for this tag, and tries to publish the artifacts github, check it on [travis the branch list](https://travis-ci.org/mevansam/terraform-provider-cloudfoundry/branches)
+* edit the release notes in the [github release page](https://github.com/mevansam/terraform-provider-cloudfoundry/releases)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -8,9 +8,9 @@ default: build
 release:
 	rm -fr bin
 	mkdir -p bin
-	GOARCH=amd64 GOOS=windows go build -o bin/terraform-provider-cf_windows_amd64.exe
-	GOARCH=amd64 GOOS=linux go build -o bin/terraform-provider-cf_linux_amd64
-	GOARCH=amd64 GOOS=darwin go build -o bin/terraform-provider-cf_darwin_amd64
+	GOARCH=amd64 GOOS=windows go build -o bin/terraform-provider-cloudfoundry_windows_amd64.exe
+	GOARCH=amd64 GOOS=linux go build -o bin/terraform-provider-cloudfoundry_linux_amd64
+	GOARCH=amd64 GOOS=darwin go build -o bin/terraform-provider-cloudfoundry_darwin_amd64
 
 build: check
 	go install

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-Cloud Foundry Terraform Provider [![Build Status](https://travis-ci.org/mevansam/terraform-provider-cf.svg?branch=master)](https://travis-ci.org/mevansam/terraform-provider-cf)
+Cloud Foundry Terraform Provider [![Build Status](https://travis-ci.org/mevansam/terraform-provider-cloudfoundry.svg?branch=master)](https://travis-ci.org/mevansam/terraform-provider-cloudfoundry)
 ================================
 
 Overview
 --------
 
-This Terraform provider plugin allows you to configure a Cloud Foundry environment declaratively using [HCL](https://github.com/hashicorp/hcl). The online documentation for the Terraform Cloud Foundry resource is available on the [wiki](https://github.com/mevansam/terraform-provider-cf/wiki).
+This Terraform provider plugin allows you to configure a Cloud Foundry environment declaratively using [HCL](https://github.com/hashicorp/hcl). The online documentation for the Terraform Cloud Foundry resource is available on the [wiki](https://github.com/mevansam/terraform-provider-cloudfoundry/wiki).
 
 Requirements
 ------------
@@ -15,17 +15,17 @@ Requirements
 Building The Provider
 ---------------------
 
-Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-cf`
+Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-cloudfoundry`
 
 ```sh
 $ mkdir -p $GOPATH/src/github.com/terraform-providers; cd $GOPATH/src/github.com/terraform-providers
-$ git clone git@github.com:terraform-providers/terraform-provider-cf
+$ git clone git@github.com:terraform-providers/terraform-provider-cloudfoundry
 ```
 
 Enter the provider directory and build the provider
 
 ```sh
-$ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-cf
+$ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-cloudfoundry
 $ make build
 ```
 
@@ -39,7 +39,7 @@ Developing the Provider
 
 If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.8+ is *required*). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
 
-Clone this repository to `GOPATH/src/github.com/terraform-providers/terraform-provider-cf` as its packaging structure 
+Clone this repository to `GOPATH/src/github.com/terraform-providers/terraform-provider-cloudfoundry` as its packaging structure
 has been defined such that it will be compatible with the Terraform provider plugin framwork in 0.10.x.
 
 To compile the provider, run `make build`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
@@ -47,7 +47,7 @@ To compile the provider, run `make build`. This will build the provider and put 
 ```sh
 $ make build
 ...
-$ $GOPATH/bin/terraform-provider-cf
+$ $GOPATH/bin/terraform-provider-cloudfoundry
 ...
 ```
 
@@ -87,7 +87,7 @@ To run the tests in AWS first launch PCFDev in AWS via `scripts/pcfdev-up.sh`, a
 make testacc
 ```
 
->> Acceptance tests are run against a PCF Dev instance in AWS before a release is created. Any other testing should be done using a local PCF Dev instance. 
+>> Acceptance tests are run against a PCF Dev instance in AWS before a release is created. Any other testing should be done using a local PCF Dev instance.
 
 ```sh
 $ make testacc

--- a/cloudfoundry/config.go
+++ b/cloudfoundry/config.go
@@ -1,6 +1,6 @@
 package cloudfoundry
 
-import "github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+import "github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 
 // Config -
 type Config struct {

--- a/cloudfoundry/data_source_cf_asg.go
+++ b/cloudfoundry/data_source_cf_asg.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 func dataSourceAsg() *schema.Resource {

--- a/cloudfoundry/data_source_cf_asg_test.go
+++ b/cloudfoundry/data_source_cf_asg_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 const asgDataResource = `

--- a/cloudfoundry/data_source_cf_domain.go
+++ b/cloudfoundry/data_source_cf_domain.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 func dataSourceDomain() *schema.Resource {

--- a/cloudfoundry/data_source_cf_info.go
+++ b/cloudfoundry/data_source_cf_info.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 func dataSourceInfo() *schema.Resource {

--- a/cloudfoundry/data_source_cf_org.go
+++ b/cloudfoundry/data_source_cf_org.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 func dataSourceOrg() *schema.Resource {

--- a/cloudfoundry/data_source_cf_org_quota.go
+++ b/cloudfoundry/data_source_cf_org_quota.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 func dataSourceOrgQuota() *schema.Resource {

--- a/cloudfoundry/data_source_cf_org_quota_test.go
+++ b/cloudfoundry/data_source_cf_org_quota_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 const orgQuotaDataResource = `

--- a/cloudfoundry/data_source_cf_org_test.go
+++ b/cloudfoundry/data_source_cf_org_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 const orgDataResource = `

--- a/cloudfoundry/data_source_cf_router_group.go
+++ b/cloudfoundry/data_source_cf_router_group.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 func dataSourceRouterGroup() *schema.Resource {

--- a/cloudfoundry/data_source_cf_router_group_test.go
+++ b/cloudfoundry/data_source_cf_router_group_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 const routerGroupDataResource = `

--- a/cloudfoundry/data_source_cf_service.go
+++ b/cloudfoundry/data_source_cf_service.go
@@ -6,7 +6,7 @@ import (
 	"code.cloudfoundry.org/cli/cf/models"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 func dataSourceService() *schema.Resource {

--- a/cloudfoundry/data_source_cf_service_test.go
+++ b/cloudfoundry/data_source_cf_service_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 const serviceDataResource = `

--- a/cloudfoundry/data_source_cf_space.go
+++ b/cloudfoundry/data_source_cf_space.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 func dataSourceSpace() *schema.Resource {

--- a/cloudfoundry/data_source_cf_space_quota.go
+++ b/cloudfoundry/data_source_cf_space_quota.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 func dataSourceSpaceQuota() *schema.Resource {
@@ -30,9 +30,9 @@ func dataSourceSpaceQuotaRead(d *schema.ResourceData, meta interface{}) (err err
 	}
 
 	var (
-		org    *string
-		name   string
-		quota  cfapi.CCQuota
+		org   *string
+		name  string
+		quota cfapi.CCQuota
 	)
 
 	name = d.Get("name").(string)

--- a/cloudfoundry/data_source_cf_space_quota_test.go
+++ b/cloudfoundry/data_source_cf_space_quota_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 const spaceQuotaDataResource = `

--- a/cloudfoundry/data_source_cf_space_test.go
+++ b/cloudfoundry/data_source_cf_space_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 const spaceDataResource1 = `

--- a/cloudfoundry/data_source_cf_stack.go
+++ b/cloudfoundry/data_source_cf_stack.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 func dataSourceStack() *schema.Resource {

--- a/cloudfoundry/data_source_cf_stack_test.go
+++ b/cloudfoundry/data_source_cf_stack_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 const stackDataResource = `

--- a/cloudfoundry/data_source_cf_user.go
+++ b/cloudfoundry/data_source_cf_user.go
@@ -6,7 +6,7 @@ import (
 	"code.cloudfoundry.org/cli/cf/models"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 func dataSourceUser() *schema.Resource {

--- a/cloudfoundry/data_source_cf_user_test.go
+++ b/cloudfoundry/data_source_cf_user_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 const userDataResource = `

--- a/cloudfoundry/import_cf_app.go
+++ b/cloudfoundry/import_cf_app.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 const dlImportPath = "%s/v2/apps/%s/download"

--- a/cloudfoundry/import_cf_service_instance_test.go
+++ b/cloudfoundry/import_cf_service_instance_test.go
@@ -8,7 +8,7 @@ import (
 	"code.cloudfoundry.org/cli/cf/errors"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 func TestAccServiceInstance_importBasic(t *testing.T) {

--- a/cloudfoundry/import_cf_service_plan_access.go
+++ b/cloudfoundry/import_cf_service_plan_access.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 func resourceServicePlanAccessImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {

--- a/cloudfoundry/import_cf_space.go
+++ b/cloudfoundry/import_cf_space.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 func resourceSpaceImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {

--- a/cloudfoundry/provider_test.go
+++ b/cloudfoundry/provider_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 var testAccProviders map[string]terraform.ResourceProvider

--- a/cloudfoundry/repo/git_repository_test.go
+++ b/cloudfoundry/repo/git_repository_test.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/repo"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/repo"
 
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"

--- a/cloudfoundry/repo/github_release_test.go
+++ b/cloudfoundry/repo/github_release_test.go
@@ -8,8 +8,9 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/repo"
 	"os"
+
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/repo"
 )
 
 func TestGithubReleaseRepo(t *testing.T) {

--- a/cloudfoundry/resource_cf_app.go
+++ b/cloudfoundry/resource_cf_app.go
@@ -13,8 +13,8 @@ import (
 	"code.cloudfoundry.org/cli/cf/terminal"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/repo"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/repo"
 )
 
 // DefaultAppTimeout - Timeout (in seconds) when pushing apps to CF

--- a/cloudfoundry/resource_cf_app_test.go
+++ b/cloudfoundry/resource_cf_app_test.go
@@ -6,7 +6,7 @@ import (
 	"code.cloudfoundry.org/cli/cf/errors"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 	"os"
 )
 
@@ -239,7 +239,7 @@ data "cloudfoundry_space" "space" {
 resource "cloudfoundry_route" "test-app" {
 	domain = "${data.cloudfoundry_domain.local.id}"
 	space = "${data.cloudfoundry_space.space.id}"
-	hostname = "test-app" 
+	hostname = "test-app"
     target = {app = "${cloudfoundry_app.test-app.id}"}
 }
 resource "cloudfoundry_app" "test-app" {

--- a/cloudfoundry/resource_cf_asg.go
+++ b/cloudfoundry/resource_cf_asg.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 const protocolICMP = "icmp"

--- a/cloudfoundry/resource_cf_asg_test.go
+++ b/cloudfoundry/resource_cf_asg_test.go
@@ -9,14 +9,14 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 const securityGroup = `
 resource "cloudfoundry_asg" "rmq" {
 
 	name = "rmq-dev"
-	
+
     rule {
         protocol = "tcp"
         destination = "192.168.1.100"
@@ -35,7 +35,7 @@ const securityGroupUpdate = `
 resource "cloudfoundry_asg" "rmq" {
 
 	name = "rmq-dev"
-	
+
     rule {
         protocol = "tcp"
         destination = "192.168.1.100"

--- a/cloudfoundry/resource_cf_buildpack.go
+++ b/cloudfoundry/resource_cf_buildpack.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/repo"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/repo"
 )
 
 func resourceBuildpack() *schema.Resource {

--- a/cloudfoundry/resource_cf_buildpack_test.go
+++ b/cloudfoundry/resource_cf_buildpack_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 	"os"
 )
 
@@ -19,7 +19,7 @@ variable "tomee_buildpack_ver" {
 }
 
 resource "cloudfoundry_buildpack" "tomee" {
-	
+
 	name = "tomee-buildpack"
 
 	github_release {
@@ -40,7 +40,7 @@ variable "tomee_buildpack_ver" {
 }
 
 resource "cloudfoundry_buildpack" "tomee" {
-	
+
 	name = "tomee-buildpack"
 	position = 5
 	enabled = false
@@ -60,14 +60,14 @@ resource "cloudfoundry_buildpack" "tomee" {
 const buildpackResourceUpdate2 = `
 
 resource "cloudfoundry_buildpack" "tomee" {
-	
+
 	name = "tomee-buildpack"
 	position = 5
 	enabled = true
 	locked = false
 
 	git {
-		url = "https://github.com/cloudfoundry-community/tomee-buildpack"				
+		url = "https://github.com/cloudfoundry-community/tomee-buildpack"
 	}
 }
 `

--- a/cloudfoundry/resource_cf_default_asg.go
+++ b/cloudfoundry/resource_cf_default_asg.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 func resourceDefaultAsg() *schema.Resource {

--- a/cloudfoundry/resource_cf_default_asg_test.go
+++ b/cloudfoundry/resource_cf_default_asg_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 const defaultRunningSecurityGroupResource = `

--- a/cloudfoundry/resource_cf_domain.go
+++ b/cloudfoundry/resource_cf_domain.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 func resourceDomain() *schema.Resource {

--- a/cloudfoundry/resource_cf_domain_test.go
+++ b/cloudfoundry/resource_cf_domain_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 const domainResourceShared = `

--- a/cloudfoundry/resource_cf_evg.go
+++ b/cloudfoundry/resource_cf_evg.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 func resourceEvg() *schema.Resource {

--- a/cloudfoundry/resource_cf_evg_test.go
+++ b/cloudfoundry/resource_cf_evg_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 const evgRunningResource = `

--- a/cloudfoundry/resource_cf_feature_flags.go
+++ b/cloudfoundry/resource_cf_feature_flags.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 // FlagStatusEnabled - Status returned by CF api for enabled flags

--- a/cloudfoundry/resource_cf_feature_flags_test.go
+++ b/cloudfoundry/resource_cf_feature_flags_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 const configResource = `

--- a/cloudfoundry/resource_cf_org.go
+++ b/cloudfoundry/resource_cf_org.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 func resourceOrg() *schema.Resource {

--- a/cloudfoundry/resource_cf_org_quota.go
+++ b/cloudfoundry/resource_cf_org_quota.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 func resourceOrgQuota() *schema.Resource {

--- a/cloudfoundry/resource_cf_org_quota_test.go
+++ b/cloudfoundry/resource_cf_org_quota_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 const orgQuotaResource = `

--- a/cloudfoundry/resource_cf_org_test.go
+++ b/cloudfoundry/resource_cf_org_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 const orgResource = `

--- a/cloudfoundry/resource_cf_private_domain_access.go
+++ b/cloudfoundry/resource_cf_private_domain_access.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 func resourcePrivateDomainAccess() *schema.Resource {

--- a/cloudfoundry/resource_cf_private_domain_access_test.go
+++ b/cloudfoundry/resource_cf_private_domain_access_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 const privateDomainAccessResourceCreate = `

--- a/cloudfoundry/resource_cf_route.go
+++ b/cloudfoundry/resource_cf_route.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 func resourceRoute() *schema.Resource {

--- a/cloudfoundry/resource_cf_route_service_binding.go
+++ b/cloudfoundry/resource_cf_route_service_binding.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 func resourceRouteServiceBinding() *schema.Resource {

--- a/cloudfoundry/resource_cf_route_service_binding_test.go
+++ b/cloudfoundry/resource_cf_route_service_binding_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 	git "gopkg.in/src-d/go-git.v4"
 )
 

--- a/cloudfoundry/resource_cf_route_test.go
+++ b/cloudfoundry/resource_cf_route_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 const routeResource = `

--- a/cloudfoundry/resource_cf_service_broker.go
+++ b/cloudfoundry/resource_cf_service_broker.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 func resourceServiceBroker() *schema.Resource {

--- a/cloudfoundry/resource_cf_service_broker_test.go
+++ b/cloudfoundry/resource_cf_service_broker_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 const sbResource = `

--- a/cloudfoundry/resource_cf_service_instance.go
+++ b/cloudfoundry/resource_cf_service_instance.go
@@ -9,7 +9,7 @@ import (
 	"code.cloudfoundry.org/cli/cf/terminal"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 	"strings"
 )
 

--- a/cloudfoundry/resource_cf_service_instance_test.go
+++ b/cloudfoundry/resource_cf_service_instance_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 const serviceInstanceResourceCreate = `

--- a/cloudfoundry/resource_cf_service_key.go
+++ b/cloudfoundry/resource_cf_service_key.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 func resourceServiceKey() *schema.Resource {

--- a/cloudfoundry/resource_cf_service_key_test.go
+++ b/cloudfoundry/resource_cf_service_key_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 const serviceKeyResource = `

--- a/cloudfoundry/resource_cf_service_plan_access.go
+++ b/cloudfoundry/resource_cf_service_plan_access.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 func resourceServicePlanAccess() *schema.Resource {

--- a/cloudfoundry/resource_cf_service_plan_access_test.go
+++ b/cloudfoundry/resource_cf_service_plan_access_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 const saResource = `

--- a/cloudfoundry/resource_cf_space.go
+++ b/cloudfoundry/resource_cf_space.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 func resourceSpace() *schema.Resource {

--- a/cloudfoundry/resource_cf_space_quota.go
+++ b/cloudfoundry/resource_cf_space_quota.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 func resourceSpaceQuota() *schema.Resource {

--- a/cloudfoundry/resource_cf_space_quota_test.go
+++ b/cloudfoundry/resource_cf_space_quota_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 const spaceQuotaResource = `

--- a/cloudfoundry/resource_cf_space_test.go
+++ b/cloudfoundry/resource_cf_space_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 const spaceResource = `

--- a/cloudfoundry/resource_cf_user.go
+++ b/cloudfoundry/resource_cf_user.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 func resourceUser() *schema.Resource {

--- a/cloudfoundry/resource_cf_user_provided_service.go
+++ b/cloudfoundry/resource_cf_user_provided_service.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/structure"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 func resourceUserProvidedService() *schema.Resource {

--- a/cloudfoundry/resource_cf_user_provided_service_test.go
+++ b/cloudfoundry/resource_cf_user_provided_service_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 const userProvidedServiceResourceCreate = `

--- a/cloudfoundry/resource_cf_user_test.go
+++ b/cloudfoundry/resource_cf_user_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/cfapi"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/cfapi"
 )
 
 const ldapUserResource = `

--- a/cloudfoundry/utils_repo.go
+++ b/cloudfoundry/utils_repo.go
@@ -2,7 +2,7 @@ package cloudfoundry
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry/repo"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/repo"
 )
 
 var repoManager *repo.RepoManager = repo.NewRepoManager()

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/terraform-providers/terraform-provider-cf/cloudfoundry"
+	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry"
 )
 
 func main() {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2139,5 +2139,5 @@
 			"revisionTime": "2017-04-07T17:21:22Z"
 		}
 	],
-	"rootPath": "github.com/terraform-providers/terraform-provider-cf"
+	"rootPath": "github.com/terraform-providers/terraform-provider-cloudfoundry"
 }


### PR DESCRIPTION
This PR is created for Issue #146 , which resolved the broken imports and mistakes in `README` and `CONTRIBUTING`. 

Please pay attention that tavis-ci is now broken which is expected to be fixed after renaming the git-repo. To do so, one could refer to [Renaming a repository](https://help.github.com/articles/renaming-a-repository/).

fixes #146
