### PR TITLE
Add type assertion check. Fixes crash in #156

### DIFF
--- a/cloudfoundry/cfapi/route_manager.go
+++ b/cloudfoundry/cfapi/route_manager.go
@@ -254,7 +254,9 @@ func (rm *RouteManager) readRouteMappings(id, key string) (mappings []map[string
 			mapping["route"] = routeResource["entity"].(map[string]interface{})["route_guid"].(string)
 		}
 		if v, ok := routeResource["entity"].(map[string]interface{})["app_port"]; ok {
-			mapping["port"] = int(v.(float64))
+			if port, ok := v.(float64); ok {
+				mapping["port"] = int(port)
+			}
 		}
 		mappings = append(mappings, mapping)
 		return true


### PR DESCRIPTION
The type assertion could be done to `int` directly, but wanted to stay as close to original code as possible. Larger refactoring might be needed as well but not familiar with code base enough to tackle it just yet.

Fixes #156