### PR TITLE
Fix documentation following provider rename

### DIFF
--- a/website/docs/d/asg.html.markdown
+++ b/website/docs/d/asg.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Get information on a Cloud Foundry Application Security Group.
 ---
 
-# cf\_asg
+# cloudfoundry\_asg
 
 Gets information on a Cloud Foundry application security group.
 

--- a/website/docs/d/domain.html.markdown
+++ b/website/docs/d/domain.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Get information on a Cloud Foundry Domain.
 ---
 
-# cf\_domain
+# cloudfoundry\_domain
 
 Gets information on a Cloud Foundry domain.
 

--- a/website/docs/d/info.html.markdown
+++ b/website/docs/d/info.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Get information on a Cloud Foundry target.
 ---
 
-# cf\_info
+# cloudfoundry\_info
 
 Gets information on a Cloud Foundry target.
 

--- a/website/docs/d/org.html.markdown
+++ b/website/docs/d/org.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Get information on a Cloud Foundry Organization.
 ---
 
-# cf\_org
+# cloudfoundry\_org
 
 Gets information on a Cloud Foundry organization.
 

--- a/website/docs/d/router_group.html.markdown
+++ b/website/docs/d/router_group.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Get information on a Cloud Foundry router_group.
 ---
 
-# cf\_router\_group
+# cloudfoundry\_router\_group
 
 Gets information on a particular Cloud Foundry router group. Router groups are used to declare [TCP domains](https://docs.cloudfoundry.org/devguide/deploy-apps/router_groups.html) and need to be referenced when declaring [TCP routes](https://docs.cloudfoundry.org/adminguide/enabling-tcp-routing.html).
 

--- a/website/docs/d/service.html.markdown
+++ b/website/docs/d/service.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Get information on a Cloud Foundry Service.
 ---
 
-# cf\_service
+# cloudfoundry\_service
 
 Gets information on a Cloud Foundry service definition.
 

--- a/website/docs/d/space.html.markdown
+++ b/website/docs/d/space.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Get information on a Cloud Foundry Space.
 ---
 
-# cf\_space
+# cloudfoundry\_space
 
 Gets information on a Cloud Foundry space.
 

--- a/website/docs/d/space_quota.html.markdown
+++ b/website/docs/d/space_quota.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Get information on a Cloud Foundry space Quota.
 ---
 
-# cf\_space\_quota
+# cloudfoundry\_space\_quota
 
 Gets information on a Cloud Foundry space quota.
 

--- a/website/docs/d/stack.html.markdown
+++ b/website/docs/d/stack.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Get information on a Cloud Foundry stack.
 ---
 
-# cf\_stack
+# cloudfoundry\_stack
 
 Gets information on a particular Cloud Foundry [stack](https://docs.cloudfoundry.org/devguide/deploy-apps/stacks.html).
 

--- a/website/docs/d/user.html.markdown
+++ b/website/docs/d/user.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Get information on a Cloud Foundry User.
 ---
 
-# cf\_user
+# cloudfoundry\_user
 
 Gets information on a Cloud Foundry user.
 

--- a/website/docs/r/app.html.markdown
+++ b/website/docs/r/app.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a Cloud Foundry Application resource.
 ---
 
-# cf\_app
+# cloudfoundry\_app
 
 Provides a Cloud Foundry [application](https://docs.cloudfoundry.org/devguide/deploy-apps/deploy-app.html) resource.
 

--- a/website/docs/r/asg.html.markdown
+++ b/website/docs/r/asg.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a Cloud Foundry Application Security Group resource.
 ---
 
-# cf\_asg
+# cloudfoundry\_asg
 
 Provides an [application security group](https://docs.cloudfoundry.org/adminguide/app-sec-groups.html) 
 resource for Cloud Foundry. This resource defines egress rules that can be applied to containers that 

--- a/website/docs/r/buildpack.html.markdown
+++ b/website/docs/r/buildpack.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a Cloud Foundry Buildpack resource.
 ---
 
-# cf\_buildpack
+# cloudfoundry\_buildpack
 
 Provides a Cloud Foundry resource for managing Cloud Foundry admin [buildpacks](https://docs.cloudfoundry.org/adminguide/buildpacks.html).
 

--- a/website/docs/r/config.html.markdown
+++ b/website/docs/r/config.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a Cloud Foundry configuration resource.
 ---
 
-# cf\_config
+# cloudfoundry\_config
 
 Provides a Cloud Foundry configuration resource for managing Cloud Foundry [feature](https://docs.cloudfoundry.org/adminguide/listing-feature-flags.html) flags.
 

--- a/website/docs/r/default_asg.html.markdown
+++ b/website/docs/r/default_asg.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a Cloud Foundry Default Application Security Group resource.
 ---
 
-# cf\_default\_asg
+# cloudfoundry\_default\_asg
 
 Provides a resource for modifying the default staging or running
 [application security groups](https://docs.cloudfoundry.org/adminguide/app-sec-groups.html).

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a Cloud Foundry Domain resource.
 ---
 
-# cf\_domain
+# cloudfoundry\_domain
 
 Provides a resource for managing shared or private 
 [domains](https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#domains) in Cloud Foundry.

--- a/website/docs/r/evg.html.markdown
+++ b/website/docs/r/evg.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a Cloud Foundry Environment Variable Group resource.
 ---
 
-# cf\_evg
+# cloudfoundry\_evg
 
 Provides a resource for modifying the running or staging [environment variable groups](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#evgroups) in Cloud Foundry.
 

--- a/website/docs/r/org.html.markdown
+++ b/website/docs/r/org.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a Cloud Foundry Org resource.
 ---
 
-# cf\_org
+# cloudfoundry\_org
 
 Provides a Cloud Foundry resource for managing Cloud Foundry [organizations](https://docs.cloudfoundry.org/concepts/roles.html), assigning quota definitions, and members. 
 

--- a/website/docs/r/org_quota.html.markdown
+++ b/website/docs/r/org_quota.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a Cloud Foundry Org Quota resource.
 ---
 
-# cf\_org\_quota
+# cloudfoundry\_org\_quota
 
 Provides a Cloud Foundry resource to manage org [quotas](https://docs.cloudfoundry.org/adminguide/quota-plans.html) definitions.
 

--- a/website/docs/r/private_domain_access.html.markdown
+++ b/website/docs/r/private_domain_access.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a Cloud Foundry private domain access resource.
 ---
 
-# cf\_private\_domain\_access
+# cloudfoundry\_private\_domain\_access
 
 Provides a resource for sharing access to [private domains](https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#domains) with other Cloud Foundry Organizations.
 

--- a/website/docs/r/route.html.markdown
+++ b/website/docs/r/route.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a Cloud Foundry route resource.
 ---
 
-# cf\_route
+# cloudfoundry\_route
 
 Provides a Cloud Foundry resource for managing Cloud Foundry application [routes](https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html).
 

--- a/website/docs/r/route_service_binding.html.markdown
+++ b/website/docs/r/route_service_binding.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a Cloud Foundry resource to bind a service instance to a route.
 ---
 
-# cf\_route\_service\_binding
+# cloudfoundry\_route\_service\_binding
 
 Provides a Cloud Foundry resource for [binding](https://docs.cloudfoundry.org/devguide/services/route-binding.html#bind) of service instances to routes.
 

--- a/website/docs/r/service_broker.html.markdown
+++ b/website/docs/r/service_broker.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a Cloud Foundry Service Broker resource.
 ---
 
-# cf\_service\_broker
+# cloudfoundry\_service\_broker
 
 Provides a Cloud Foundry resource for managing [service brokers](https://docs.cloudfoundry.org/services/) definitions. 
 

--- a/website/docs/r/service_instance.html.markdown
+++ b/website/docs/r/service_instance.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a Cloud Foundry Service Instance.
 ---
 
-# cf\_service\_instance
+# cloudfoundry\_service\_instance
 
 Provides a Cloud Foundry resource for managing Cloud Foundry [Service Instances](https://docs.cloudfoundry.org/devguide/services/) within spaces.
 

--- a/website/docs/r/service_key.html.markdown
+++ b/website/docs/r/service_key.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a Cloud Foundry Service Key.
 ---
 
-# cf\_service\_key
+# cloudfoundry\_service\_key
 
 Provides a Cloud Foundry resource for managing Cloud Foundry [Service Keys](https://docs.cloudfoundry.org/devguide/services/#service-keys).
 

--- a/website/docs/r/service_plan_access.html.markdown
+++ b/website/docs/r/service_plan_access.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a Cloud Foundry Service Access resource.
 ---
 
-# cf\_service\_access
+# cloudfoundry\_service\_access
 
 Provides a Cloud Foundry resource for managing [access](https://docs.cloudfoundry.org/services/access-control.html)
 to service plans published by Cloud Foundry [service brokers](https://docs.cloudfoundry.org/services/).

--- a/website/docs/r/space.html.markdown
+++ b/website/docs/r/space.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a Cloud Foundry Space resource.
 ---
 
-# cf\_space
+# cloudfoundry\_space
 
 Provides a Cloud Foundry resource for managing Cloud Foundry [spaces](https://docs.cloudfoundry.org/concepts/roles.html) within organizations.
 

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a Cloud Foundry User resource.
 ---
 
-# cf\_user
+# cloudfoundry\_user
 
 Provides a Cloud Foundry resource for registering users. This resource provides extended 
 functionality to attach additional UAA roles to the user.

--- a/website/docs/r/user_provided_service.html.markdown
+++ b/website/docs/r/user_provided_service.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a Cloud Foundry User Provided Service.
 ---
 
-# cf\_user_provided_service
+# cloudfoundry\_user_provided_service
 
 Provides a Cloud Foundry resource for managing Cloud Foundry [User Provided Services](https://docs.cloudfoundry.org/devguide/services/user-provided.html) within spaces.
 


### PR DESCRIPTION
Resource names "cf_" prefix become "cloudfoundry_" in markdown headers

Contributes to #44