### PR TITLE
[WIP] Allow http authentication on git application resources

### DIFF
--- a/website/docs/r/app.html.markdown
+++ b/website/docs/r/app.html.markdown
@@ -62,9 +62,9 @@ One of the following arguments must be declared to locate application source or 
 
 ~> **NOTE:** Arguments "`tag`" and "`branch`" are mutually exclusive.
 
-~> **NOTE:** Builtin credentials like `https://user:password@host` or `ssh://git@host` is not supported.
+~> **NOTE:** Builtin credentials like `https://user:password@host` or `ssh://git@host` are not supported.
 
-~> **NOTE:** If a git SSH "`key`" is provided and it is protected the "`password`" argument should be used as the key's password.
+~> **NOTE:** If a git SSH "`key`" is provided and the key is password-protected, then the "`password`" argument should be used as the key's password.
 
 * `github_release` - (Optional, String) The github release where to download the application archive from.
 

--- a/website/docs/r/app.html.markdown
+++ b/website/docs/r/app.html.markdown
@@ -62,8 +62,7 @@ One of the following arguments must be declared to locate application source or 
 
 ~> **NOTE:** Arguments "`tag`" and "`branch`" are mutually exclusive.
 
-~> **NOTE:** The "`user`" argument tells the provider that an authentication is requiered. Builtin
-   credentials like `https://user:password@host` or `ssh://git@host` is not supported.
+~> **NOTE:** Builtin credentials like `https://user:password@host` or `ssh://git@host` is not supported.
 
 ~> **NOTE:** If a git SSH "`key`" is provided and it is protected the "`password`" argument should be used as the key's password.
 

--- a/website/docs/r/app.html.markdown
+++ b/website/docs/r/app.html.markdown
@@ -32,7 +32,7 @@ The following arguments are supported:
 * `disk_quota` - (Optional, Number) The disk space to be allocated for each application instance in megabytes. If not provided, default disk quota is retrieved from Cloud Foundry and assigned.
 * `stack` - (Optional) The GUID of the stack the application will be deployed to. Use the [`cloudfoundry_stack`](/docs/providers/cloudfoundry/d/stack.html) data resource to lookup the stack GUID to override Cloud Foundry default.
 * `buildpack` - (Optional, String) The buildpack used to stage the application. There are multiple options to choose from:
-   * a Git URL (e.g. https://github.com/cloudfoundry/java-buildpack.git) or a Git URL with a branch or tag (e.g. https://github.com/cloudfoundry/java-buildpack.git#v3.3.0 for v3.3.0 tag) 
+   * a Git URL (e.g. https://github.com/cloudfoundry/java-buildpack.git) or a Git URL with a branch or tag (e.g. https://github.com/cloudfoundry/java-buildpack.git#v3.3.0 for v3.3.0 tag)
    * an installed admin buildpack name (e.g. my-buildpack)
    * an empty blank string to use built-in buildpacks (i.e. autodetection)
 * `command` - (Optional, String) A custom start command for the application. This overrides the start command provided by the buildpack.
@@ -46,21 +46,26 @@ One of the following arguments must be declared to locate application source or 
 
 * `url` - (Optional, String) The URL for the application binary. A local path may be referenced via "`file://...`".
 
-* `docker_image` - (Optional, String) The URL to the docker image with tag e.g registry.example.com:5000/user/repository/tag or docker image name from the public repo e.g. redis:4.0 
-* `docker_credentials` - (Optional) Defines login credentials for private docker repositories 
-  - `username` - (Required, String) Username for the private docker repo 
-  - `password` - (Required, String) Password for the private docker repo 
- 
+* `docker_image` - (Optional, String) The URL to the docker image with tag e.g registry.example.com:5000/user/repository/tag or docker image name from the public repo e.g. redis:4.0
+* `docker_credentials` - (Optional) Defines login credentials for private docker repositories
+  - `username` - (Required, String) Username for the private docker repo
+  - `password` - (Required, String) Password for the private docker repo
+
 * `git` - (Optional, String) The git repository where to pull the application source from.
 
-  - `url` - (Required, String) The git URL for the application repository.
+  - `url` - (Required, String) The git URL for the application repository. Supported schemes are `http://`, `https://`, `ssh://` and `file://`
   - `branch` - (Optional, String) The branch of from which the repository contents should be retrieved.
   - `tag` - (Optional, String) The version tag of the contents to retrieve.
   - `key` - (Optional, String) The git private key to access a private repo via SSH.
   - `user` - (Optional, String) Git user for accessing a private repo.
   - `password` - (Optional, String) Git password for accessing a private repo.
 
-~> **NOTE:** Arguments "`tag`" and "`branch`" are mutually exclusive. If a git SSH "`key`" is provided and it is protected the "`password`" argument should be used as the key's password.
+~> **NOTE:** Arguments "`tag`" and "`branch`" are mutually exclusive.
+
+~> **NOTE:** The "`user`" argument tells the provider that an authentication is requiered. Builtin
+   credentials like `https://user:password@host` or `ssh://git@host` is not supported.
+
+~> **NOTE:** If a git SSH "`key`" is provided and it is protected the "`password`" argument should be used as the key's password.
 
 * `github_release` - (Optional, String) The github release where to download the application archive from.
 
@@ -83,7 +88,7 @@ One of the following arguments must be declared to locate application source or 
   - `service_instance` - (Required, String) The service instance GUID.
   - `params` - (Optional, Map) A list of key/value parameters used by the service broker to create the binding. Defaults to empty map.
 
-~> **NOTE:** Modifying this argument will cause the application to be restaged.   
+~> **NOTE:** Modifying this argument will cause the application to be restaged.
 
 ### Routing
 
@@ -96,7 +101,7 @@ One of the following arguments must be declared to locate application source or 
 
 ### Environment Variables
 
-* `environment` - (Optional, Map) Key/value pairs of custom environment variables to set in your app. Does not include any [system or service variables](http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#app-system-env). 
+* `environment` - (Optional, Map) Key/value pairs of custom environment variables to set in your app. Does not include any [system or service variables](http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#app-system-env).
 
 ~> **NOTE:** Modifying this argument will cause the application to be restaged.
 


### PR DESCRIPTION
This PR allows to use **user/password** with **http(s)** git repositories in  *cloudfoundry_app* resource.

Previous implementation was using a `ssh.Password` object as `AuthMethod` regardless to the protocol provided in repository url.

https://github.com/mevansam/terraform-provider-cf/blob/de9c8d3ee0ecc5bfa28fb00e4b2aea6ee5b84770/cloudfoundry/repo/repo_manager.go#L59-L87

The proposed implementation:
* creates the correct `AuthMethod` object depending on repository scheme and provided resource parameters (user, password, private_key)
* validates consistency between parameters  and repository scheme in order generate a comprehensible error message

https://github.com/mevansam/terraform-provider-cf/blob/f4430876fdf017002741a9812a21662dbbfc9921/cloudfoundry/repo/repo_manager.go#L45-L82