### PR TITLE
Migration script fix: Copying the key values over, as they might change on-the-fly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.X (future version)
+
+* We have created a migration script in `scripts/migration` to migrate from versions below 0.9.9, which helps to mitigate the breaking changes in the provider [#171](https://github.com/mevansam/terraform-provider-cf/pull/171) and [#165](https://github.com/mevansam/terraform-provider-cf/pull/165)
+
 ## 0.9.9 (September 27, 2018)
 
 BREAKING CHANGES:

--- a/scripts/migration/migrate_tf_cf.py
+++ b/scripts/migration/migrate_tf_cf.py
@@ -51,7 +51,7 @@ class JSONConverter(Converter):
         provider_regex_replacement = r'provider.cloudfoundry'
         modules = state_dict['modules']
         for module in modules:
-            for key, value_dict in module['resources'].items():
+            for key, value_dict in list(module['resources'].items()):
                 # 1. change the stuff in the value dict
                 # 1a. change each moduel in depends_on
                 depending_modules = value_dict['depends_on']


### PR DESCRIPTION
We had an issue during the migration, that not all cf_ resources get migrated to cloudfoundry_ resource. This small fix should handle the issue.