### PR TITLE
fix app deployed with syslog_drain service

### DIFF
--- a/cloudfoundry/cfapi/app_manager.go
+++ b/cloudfoundry/cfapi/app_manager.go
@@ -548,6 +548,8 @@ func (am *AppManager) ReadServiceBindingsByServiceInstance(serviceInstanceID str
 }
 
 // readServiceBindings -
+//
+// 1. Credentials can be null for syslog_drain services
 func (am *AppManager) readServiceBindings(id, key string) (mappings []map[string]interface{}, err error) {
 
 	resource := make(map[string]interface{})
@@ -578,10 +580,6 @@ func (am *AppManager) readServiceBindings(id, key string) (mappings []map[string
 					mapping["credentials"] = c.(map[string]interface{})
 				}
 			}
-
-			// if v, ok := routeResource["entity"].(map[string]interface{})["credentials"]; ok {
-			// 	mapping["credentials"] = v.(map[string]interface{})
-			// }
 
 			mappings = append(mappings, mapping)
 			return true

--- a/cloudfoundry/cfapi/app_manager.go
+++ b/cloudfoundry/cfapi/app_manager.go
@@ -500,6 +500,8 @@ func (am *AppManager) StopApp(appID string, timeout time.Duration) (err error) {
 }
 
 // CreateServiceBinding -
+//
+// 1. Credentials can be null for syslog_drain services
 func (am *AppManager) CreateServiceBinding(
 	appID string,
 	serviceInstanceID string,
@@ -524,8 +526,13 @@ func (am *AppManager) CreateServiceBinding(
 	}
 
 	bindingID = response["metadata"].(map[string]interface{})["guid"].(string)
-	if v, ok := response["entity"].(map[string]interface{})["credentials"]; ok {
-		credentials = v.(map[string]interface{})
+
+	if v, ok := response["entity"]; ok {
+		entity := v.(map[string]interface{})
+		// 1.
+		if c, ok2 := entity["credentials"]; ok2 && (c != nil) {
+			credentials = c.(map[string]interface{})
+		}
 	}
 	return bindingID, credentials, nil
 }

--- a/cloudfoundry/cfapi/app_manager.go
+++ b/cloudfoundry/cfapi/app_manager.go
@@ -571,9 +571,17 @@ func (am *AppManager) readServiceBindings(id, key string) (mappings []map[string
 				mapping["service_instance"] = routeResource["entity"].(map[string]interface{})["service_instance_guid"].(string)
 			}
 
-			if v, ok := routeResource["entity"].(map[string]interface{})["credentials"]; ok {
-				mapping["credentials"] = v.(map[string]interface{})
+			if v, ok := routeResource["entity"]; ok {
+				entity := v.(map[string]interface{})
+				// 1.
+				if c, ok2 := entity["credentials"]; ok2 && (c != nil) {
+					mapping["credentials"] = c.(map[string]interface{})
+				}
 			}
+
+			// if v, ok := routeResource["entity"].(map[string]interface{})["credentials"]; ok {
+			// 	mapping["credentials"] = v.(map[string]interface{})
+			// }
 
 			mappings = append(mappings, mapping)
 			return true


### PR DESCRIPTION
This PR fixes a terraform crash that occurs when bining an application to a `syslog_drain` type service instance