### PR TITLE
correct terraform plugins directory in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ make build
 Using the provider
 ------------------
 
-Download the release binary and copy it to the `$HOME/terraform.d/plugins/<os>_<arch>/terraform-provider-cloudfoundry`. For example `/home/youruser/terraform.d/plugins/linux_amd64/terraform-provider-cloudfoundry` for a Linux environment or `/Users/youruser/terraform.d/plugins/darwin_amd64/terraform-provider-cloudfoundry` for a MacOS environment.
+Download the release binary and copy it to the `$HOME/.terraform.d/plugins/<os>_<arch>/terraform-provider-cloudfoundry`. For example `/home/youruser/.terraform.d/plugins/linux_amd64/terraform-provider-cloudfoundry` for a Linux environment or `/Users/youruser/terraform.d/plugins/darwin_amd64/terraform-provider-cloudfoundry` for a MacOS environment (see https://www.terraform.io/docs/configuration/providers.html#third-party-plugins for more details).
 
 Developing the Provider
 -----------------------


### PR DESCRIPTION
i think the plugins directory in the installation instructions should be _~/.terraform.d/.._  instead of _~/terraform.d/.._

also see https://github.com/mevansam/terraform-provider-cf/issues/191